### PR TITLE
Encrypt path in statfs() calls

### DIFF
--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -228,6 +228,17 @@ func (fs *FS) Utimens(path string, Atime *time.Time, Mtime *time.Time, context *
 	return fs.FileSystem.Utimens(cPath, Atime, Mtime, context)
 }
 
+func (fs *FS) StatFs(path string) *fuse.StatfsOut {
+	if fs.isFiltered(path) {
+		return nil
+	}
+	cPath, err := fs.encryptPath(path)
+	if err != nil {
+		return nil
+	}
+	return fs.FileSystem.StatFs(cPath)
+}
+
 func (fs *FS) Readlink(path string, context *fuse.Context) (out string, status fuse.Status) {
 	cPath, err := fs.encryptPath(path)
 	if err != nil {


### PR DESCRIPTION
Paths in statfs() calls were not encrypted resulting in an `Function not implemented` error, when the unencrypted path didn't exist in the underlying (encrypted) filesystem.

```
$ df plain/existingdir
df: ‘plain/existingdir’: Function not implemented
```