### PR TITLE
lint fixes

### DIFF
--- a/cli_args.go
+++ b/cli_args.go
@@ -14,7 +14,7 @@ import (
 type argContainer struct {
 	debug, init, zerokey, fusedebug, openssl, passwd, foreground, version,
 	plaintextnames, quiet, nosyslog, wpanic,
-	longnames, allow_other, ro, reverse, aessiv bool
+	longnames, allowOther, ro, reverse, aessiv bool
 	masterkey, mountpoint, cipherdir, cpuprofile, extpass,
 	memprofile, o string
 	// Configuration file name override
@@ -47,7 +47,7 @@ func parseCliOpts() (args argContainer) {
 	flagSet.BoolVar(&args.nosyslog, "nosyslog", false, "Do not redirect output to syslog when running in the background")
 	flagSet.BoolVar(&args.wpanic, "wpanic", false, "When encountering a warning, panic and exit immediately")
 	flagSet.BoolVar(&args.longnames, "longnames", true, "Store names longer than 176 bytes in extra files")
-	flagSet.BoolVar(&args.allow_other, "allow_other", false, "Allow other users to access the filesystem. "+
+	flagSet.BoolVar(&args.allowOther, "allow_other", false, "Allow other users to access the filesystem. "+
 		"Only works if user_allow_other is set in /etc/fuse.conf.")
 	flagSet.BoolVar(&args.ro, "ro", false, "Mount the filesystem read-only")
 	flagSet.BoolVar(&args.reverse, "reverse", false, "Reverse mode")
@@ -71,7 +71,7 @@ func parseCliOpts() (args argContainer) {
 		args.openssl, err = strconv.ParseBool(opensslAuto)
 		if err != nil {
 			tlog.Fatal.Printf("Invalid \"-openssl\" setting: %v", err)
-			os.Exit(ERREXIT_USAGE)
+			os.Exit(ErrExitUsage)
 		}
 	}
 

--- a/cli_args.go
+++ b/cli_args.go
@@ -14,7 +14,7 @@ import (
 type argContainer struct {
 	debug, init, zerokey, fusedebug, openssl, passwd, foreground, version,
 	plaintextnames, quiet, nosyslog, wpanic,
-	longnames, allowOther, ro, reverse, aessiv bool
+	longnames, allow_other, ro, reverse, aessiv bool
 	masterkey, mountpoint, cipherdir, cpuprofile, extpass,
 	memprofile, o string
 	// Configuration file name override
@@ -47,7 +47,7 @@ func parseCliOpts() (args argContainer) {
 	flagSet.BoolVar(&args.nosyslog, "nosyslog", false, "Do not redirect output to syslog when running in the background")
 	flagSet.BoolVar(&args.wpanic, "wpanic", false, "When encountering a warning, panic and exit immediately")
 	flagSet.BoolVar(&args.longnames, "longnames", true, "Store names longer than 176 bytes in extra files")
-	flagSet.BoolVar(&args.allowOther, "allow_other", false, "Allow other users to access the filesystem. "+
+	flagSet.BoolVar(&args.allow_other, "allow_other", false, "Allow other users to access the filesystem. "+
 		"Only works if user_allow_other is set in /etc/fuse.conf.")
 	flagSet.BoolVar(&args.ro, "ro", false, "Mount the filesystem read-only")
 	flagSet.BoolVar(&args.reverse, "reverse", false, "Reverse mode")

--- a/gocryptfs-xray/xray_main.go
+++ b/gocryptfs-xray/xray_main.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	IVLen     = contentenc.DefaultIVBits / 8
-	blockSize = contentenc.DefaultBS + IVLen + cryptocore.AuthTagLen
+	ivLen     = contentenc.DefaultIVBits / 8
+	blockSize = contentenc.DefaultBS + ivLen + cryptocore.AuthTagLen
 )
 
 func errExit(err error) {
@@ -22,7 +22,7 @@ func errExit(err error) {
 }
 
 func prettyPrintHeader(h *contentenc.FileHeader) {
-	id := hex.EncodeToString(h.Id)
+	id := hex.EncodeToString(h.ID)
 	fmt.Printf("Header: Version: %d, Id: %s\n", h.Version, id)
 }
 
@@ -38,13 +38,13 @@ func main() {
 		errExit(err)
 	}
 
-	headerBytes := make([]byte, contentenc.HEADER_LEN)
+	headerBytes := make([]byte, contentenc.HeaderLen)
 	n, err := fd.ReadAt(headerBytes, 0)
 	if err == io.EOF && n == 0 {
 		fmt.Println("empty file")
 		os.Exit(0)
 	} else if err == io.EOF {
-		fmt.Printf("incomplete file header: read %d bytes, want %d\n", n, contentenc.HEADER_LEN)
+		fmt.Printf("incomplete file header: read %d bytes, want %d\n", n, contentenc.HeaderLen)
 		os.Exit(1)
 	} else if err != nil {
 		errExit(err)
@@ -57,8 +57,8 @@ func main() {
 	var i int64
 	for i = 0; ; i++ {
 		blockLen := int64(blockSize)
-		off := contentenc.HEADER_LEN + i*blockSize
-		iv := make([]byte, IVLen)
+		off := contentenc.HeaderLen + i*blockSize
+		iv := make([]byte, ivLen)
 		_, err := fd.ReadAt(iv, off)
 		if err == io.EOF {
 			break
@@ -76,7 +76,7 @@ func main() {
 			if err2 != nil {
 				errExit(err2)
 			}
-			blockLen = (fi.Size() - contentenc.HEADER_LEN) % blockSize
+			blockLen = (fi.Size() - contentenc.HeaderLen) % blockSize
 		} else if err != nil {
 			errExit(err)
 		}

--- a/init_dir.go
+++ b/init_dir.go
@@ -22,13 +22,13 @@ func initDir(args *argContainer) {
 		_, err = os.Stat(args.config)
 		if err == nil {
 			tlog.Fatal.Printf("Config file %q already exists", args.config)
-			os.Exit(ERREXIT_INIT)
+			os.Exit(ErrExitInit)
 		}
 	} else {
 		err = checkDirEmpty(args.cipherdir)
 		if err != nil {
 			tlog.Fatal.Printf("Invalid cipherdir: %v", err)
-			os.Exit(ERREXIT_INIT)
+			os.Exit(ErrExitInit)
 		}
 	}
 	// Choose password for config file
@@ -40,7 +40,7 @@ func initDir(args *argContainer) {
 	err = configfile.CreateConfFile(args.config, password, args.plaintextnames, args.scryptn, creator, args.aessiv)
 	if err != nil {
 		tlog.Fatal.Println(err)
-		os.Exit(ERREXIT_INIT)
+		os.Exit(ErrExitInit)
 	}
 	// Forward mode with filename encryption enabled needs a gocryptfs.diriv
 	// in the root dir
@@ -48,7 +48,7 @@ func initDir(args *argContainer) {
 		err = nametransform.WriteDirIV(args.cipherdir)
 		if err != nil {
 			tlog.Fatal.Println(err)
-			os.Exit(ERREXIT_INIT)
+			os.Exit(ErrExitInit)
 		}
 	}
 	mountArgs := ""

--- a/internal/configfile/config_file.go
+++ b/internal/configfile/config_file.go
@@ -14,31 +14,35 @@ import (
 import "os"
 
 const (
+	// ConfDefaultName is the default configuration file name.
 	// The dot "." is not used in base64url (RFC4648), hence
 	// we can never clash with an encrypted file.
 	ConfDefaultName = "gocryptfs.conf"
-	// In reverse mode, the config file gets stored next to the plain-text
-	// files. Make it hidden (start with dot) to not annoy the user.
+	// ConfReverseName is the default configuration file name in\ reverse mode,
+	// the config file gets stored next to the plain-text files. Make it hidden
+	// (start with dot) to not annoy the user.
 	ConfReverseName = ".gocryptfs.reverse.conf"
 )
 
+// ConfFile is the content of a config file.
 type ConfFile struct {
-	// gocryptfs version string
+	// Creator is the gocryptfs version string.
 	// This only documents the config file for humans who look at it. The actual
 	// technical info is contained in FeatureFlags.
 	Creator string
-	// Encrypted AES key, unlocked using a password hashed with scrypt
+	// EncryptedKey holds an encrypted AES key, unlocked using a password
+	// hashed with scrypt
 	EncryptedKey []byte
-	// Stores parameters for scrypt hashing (key derivation)
-	ScryptObject scryptKdf
-	// The On-Disk-Format version this filesystem uses
+	// ScryptObject stores parameters for scrypt hashing (key derivation)
+	ScryptObject ScryptKDF
+	// Version is the On-Disk-Format version this filesystem uses
 	Version uint16
-	// List of feature flags this filesystem has enabled.
+	// FeatureFlags is a list of feature flags this filesystem has enabled.
 	// If gocryptfs encounters a feature flag it does not support, it will refuse
 	// mounting. This mechanism is analogous to the ext4 feature flags that are
 	// stored in the superblock.
 	FeatureFlags []string
-	// File the config is saved to. Not exported to JSON.
+	// Filename is the name of the config file. Not exported to JSON.
 	filename string
 }
 
@@ -162,7 +166,7 @@ func LoadConfFile(filename string, password string) ([]byte, *ConfFile, error) {
 // cf.ScryptObject.
 func (cf *ConfFile) EncryptKey(key []byte, password string, logN int) {
 	// Generate derived key from password
-	cf.ScryptObject = NewScryptKdf(logN)
+	cf.ScryptObject = NewScryptKDF(logN)
 	scryptHash := cf.ScryptObject.DeriveKey(password)
 
 	// Lock master key using password-based key

--- a/internal/configfile/feature_flags.go
+++ b/internal/configfile/feature_flags.go
@@ -3,16 +3,22 @@ package configfile
 type flagIota int
 
 const (
+	// FlagPlaintextNames indicates that filenames are unencrypted.
 	FlagPlaintextNames flagIota = iota
+	// FlagDirIV indicates that a per-directory IV file is used.
 	FlagDirIV
+	// FlagEMENames is unused.
 	FlagEMENames
+	// FlagGCMIV128 is unused.
 	FlagGCMIV128
+	// FlagLongNames is unused.
 	FlagLongNames
+	// FlagAESSIV selects an AES based crypto backend.
 	FlagAESSIV
 )
 
 // knownFlags stores the known feature flags and their string representation
-var knownFlags map[flagIota]string = map[flagIota]string{
+var knownFlags = map[flagIota]string{
 	FlagPlaintextNames: "PlaintextNames",
 	FlagDirIV:          "DirIV",
 	FlagEMENames:       "EMENames",
@@ -22,7 +28,7 @@ var knownFlags map[flagIota]string = map[flagIota]string{
 }
 
 // Filesystems that do not have these feature flags set are deprecated.
-var requiredFlagsNormal []flagIota = []flagIota{
+var requiredFlagsNormal = []flagIota{
 	FlagDirIV,
 	FlagEMENames,
 	FlagGCMIV128,
@@ -30,11 +36,11 @@ var requiredFlagsNormal []flagIota = []flagIota{
 
 // Filesystems without filename encryption obviously don't have or need the
 // filename related feature flags.
-var requiredFlagsPlaintextNames []flagIota = []flagIota{
+var requiredFlagsPlaintextNames = []flagIota{
 	FlagGCMIV128,
 }
 
-// isFeatureFlagKnown verifies that we understand a feature flag
+// isFeatureFlagKnown verifies that we understand a feature flag.
 func (cf *ConfFile) isFeatureFlagKnown(flag string) bool {
 	for _, knownFlag := range knownFlags {
 		if knownFlag == flag {
@@ -44,7 +50,7 @@ func (cf *ConfFile) isFeatureFlagKnown(flag string) bool {
 	return false
 }
 
-// isFeatureFlagSet - is the feature flag "flagWant" enabled?
+// IsFeatureFlagSet returns true if the feature flag "flagWant" is enabled.
 func (cf *ConfFile) IsFeatureFlagSet(flagWant flagIota) bool {
 	flagString := knownFlags[flagWant]
 	for _, flag := range cf.FeatureFlags {

--- a/internal/configfile/feature_flags.go
+++ b/internal/configfile/feature_flags.go
@@ -7,11 +7,13 @@ const (
 	FlagPlaintextNames flagIota = iota
 	// FlagDirIV indicates that a per-directory IV file is used.
 	FlagDirIV
-	// FlagEMENames is unused.
+	// FlagEMENames indicates EME (ECB-Mix-ECB) filename encryption.
+	// This flag is mandatory since gocryptfs v1.0.
 	FlagEMENames
-	// FlagGCMIV128 is unused.
+	// FlagGCMIV128 indicates 128-bit GCM IVs.
+	// This flag is mandatory since gocryptfs v1.0.
 	FlagGCMIV128
-	// FlagLongNames is unused.
+	// FlagLongNames allows file names longer than 176 bytes.
 	FlagLongNames
 	// FlagAESSIV selects an AES based crypto backend.
 	FlagAESSIV

--- a/internal/configfile/kdf.go
+++ b/internal/configfile/kdf.go
@@ -12,12 +12,14 @@ import (
 )
 
 const (
+	// ScryptDefaultLogN is the default scrypt logN configuration parameter.
 	// 1 << 16 uses 64MB of memory,
 	// takes 4 seconds on my Atom Z3735F netbook
 	ScryptDefaultLogN = 16
 )
 
-type scryptKdf struct {
+// ScryptKDF is an instance of the scrypt key deriviation function.
+type ScryptKDF struct {
 	Salt   []byte
 	N      int
 	R      int
@@ -25,8 +27,9 @@ type scryptKdf struct {
 	KeyLen int
 }
 
-func NewScryptKdf(logN int) scryptKdf {
-	var s scryptKdf
+// NewScryptKDF returns a new instance of ScryptKDF.
+func NewScryptKDF(logN int) ScryptKDF {
+	var s ScryptKDF
 	s.Salt = cryptocore.RandBytes(cryptocore.KeyLen)
 	if logN <= 0 {
 		s.N = 1 << ScryptDefaultLogN
@@ -43,7 +46,8 @@ func NewScryptKdf(logN int) scryptKdf {
 	return s
 }
 
-func (s *scryptKdf) DeriveKey(pw string) []byte {
+// DeriveKey returns a new key from a supplied password.
+func (s *ScryptKDF) DeriveKey(pw string) []byte {
 	k, err := scrypt.Key([]byte(pw), s.Salt, s.N, s.R, s.P, s.KeyLen)
 	if err != nil {
 		log.Panicf("DeriveKey failed: %v", err)
@@ -53,6 +57,6 @@ func (s *scryptKdf) DeriveKey(pw string) []byte {
 
 // LogN - N is saved as 2^LogN, but LogN is much easier to work with.
 // This function gives you LogN = Log2(N).
-func (s *scryptKdf) LogN() int {
+func (s *ScryptKDF) LogN() int {
 	return int(math.Log2(float64(s.N)) + 0.5)
 }

--- a/internal/configfile/kdf_test.go
+++ b/internal/configfile/kdf_test.go
@@ -21,7 +21,7 @@ ok  	github.com/rfjakob/gocryptfs/cryptfs	18.772s
 */
 
 func benchmarkScryptN(n int, b *testing.B) {
-	kdf := NewScryptKdf(n)
+	kdf := NewScryptKDF(n)
 	for i := 0; i < b.N; i++ {
 		kdf.DeriveKey("test")
 	}

--- a/internal/contentenc/content.go
+++ b/internal/contentenc/content.go
@@ -69,7 +69,7 @@ func (be *ContentEnc) CipherBS() uint64 {
 	return be.cipherBS
 }
 
-// DecryptBlocks - Decrypt a number of blocks
+// DecryptBlocks decrypts a number of blocks
 // TODO refactor to three-param for
 func (be *ContentEnc) DecryptBlocks(ciphertext []byte, firstBlockNo uint64, fileID []byte) ([]byte, error) {
 	cBuf := bytes.NewBuffer(ciphertext)

--- a/internal/contentenc/content_test.go
+++ b/internal/contentenc/content_test.go
@@ -63,7 +63,7 @@ func TestCiphertextRange(t *testing.T) {
 		if alignedLength < r.length {
 			t.Errorf("alignedLength=%d is smaller than length=%d", alignedLength, r.length)
 		}
-		if (alignedOffset-HEADER_LEN)%f.cipherBS != 0 {
+		if (alignedOffset-HeaderLen)%f.cipherBS != 0 {
 			t.Errorf("alignedOffset=%d is not aligned", alignedOffset)
 		}
 		if r.offset%f.plainBS != 0 && skipBytes == 0 {
@@ -81,7 +81,7 @@ func TestBlockNo(t *testing.T) {
 	if b != 0 {
 		t.Errorf("actual: %d", b)
 	}
-	b = f.CipherOffToBlockNo(HEADER_LEN + f.cipherBS)
+	b = f.CipherOffToBlockNo(HeaderLen + f.cipherBS)
 	if b != 1 {
 		t.Errorf("actual: %d", b)
 	}

--- a/internal/contentenc/file_header.go
+++ b/internal/contentenc/file_header.go
@@ -12,42 +12,44 @@ import (
 )
 
 const (
-	// Current On-Disk-Format version
+	// CurrentVersion is the current On-Disk-Format version
 	CurrentVersion = 2
 
-	HEADER_VERSION_LEN = 2                                  // uint16
-	HEADER_ID_LEN      = 16                                 // 128 bit random file id
-	HEADER_LEN         = HEADER_VERSION_LEN + HEADER_ID_LEN // Total header length
+	headerVersionLen = 2  // uint16
+	headerIDLen      = 16 // 128 bit random file id
+	// HeaderLen is the total header length
+	HeaderLen = headerVersionLen + headerIDLen
 )
 
+// FileHeader represents the header stored on each non-empty file.
 type FileHeader struct {
 	Version uint16
-	Id      []byte
+	ID      []byte
 }
 
 // Pack - serialize fileHeader object
 func (h *FileHeader) Pack() []byte {
-	if len(h.Id) != HEADER_ID_LEN || h.Version != CurrentVersion {
+	if len(h.ID) != headerIDLen || h.Version != CurrentVersion {
 		panic("FileHeader object not properly initialized")
 	}
-	buf := make([]byte, HEADER_LEN)
-	binary.BigEndian.PutUint16(buf[0:HEADER_VERSION_LEN], h.Version)
-	copy(buf[HEADER_VERSION_LEN:], h.Id)
+	buf := make([]byte, HeaderLen)
+	binary.BigEndian.PutUint16(buf[0:headerVersionLen], h.Version)
+	copy(buf[headerVersionLen:], h.ID)
 	return buf
 
 }
 
 // ParseHeader - parse "buf" into fileHeader object
 func ParseHeader(buf []byte) (*FileHeader, error) {
-	if len(buf) != HEADER_LEN {
-		return nil, fmt.Errorf("ParseHeader: invalid length: got %d, want %d", len(buf), HEADER_LEN)
+	if len(buf) != HeaderLen {
+		return nil, fmt.Errorf("ParseHeader: invalid length: got %d, want %d", len(buf), HeaderLen)
 	}
 	var h FileHeader
-	h.Version = binary.BigEndian.Uint16(buf[0:HEADER_VERSION_LEN])
+	h.Version = binary.BigEndian.Uint16(buf[0:headerVersionLen])
 	if h.Version != CurrentVersion {
 		return nil, fmt.Errorf("ParseHeader: invalid version: got %d, want %d", h.Version, CurrentVersion)
 	}
-	h.Id = buf[HEADER_VERSION_LEN:]
+	h.ID = buf[headerVersionLen:]
 	return &h, nil
 }
 
@@ -55,6 +57,6 @@ func ParseHeader(buf []byte) (*FileHeader, error) {
 func RandomHeader() *FileHeader {
 	var h FileHeader
 	h.Version = CurrentVersion
-	h.Id = cryptocore.RandBytes(HEADER_ID_LEN)
+	h.ID = cryptocore.RandBytes(headerIDLen)
 	return &h
 }

--- a/internal/contentenc/intrablock.go
+++ b/internal/contentenc/intrablock.go
@@ -1,10 +1,10 @@
 package contentenc
 
-// intraBlock identifies a part of a file block
-type intraBlock struct {
-	// Block number in the file
+// IntraBlock identifies a part of a file block
+type IntraBlock struct {
+	// BlockNo is the block number in the file
 	BlockNo uint64
-	// Offset into block payload
+	// Skip is an offset into the block payload
 	// In forwared mode: block plaintext
 	// In reverse mode: offset into block ciphertext. Takes the header into
 	// account.
@@ -17,8 +17,8 @@ type intraBlock struct {
 	fs     *ContentEnc
 }
 
-// isPartial - is the block partial? This means we have to do read-modify-write.
-func (ib *intraBlock) IsPartial() bool {
+// IsPartial - is the block partial? This means we have to do read-modify-write.
+func (ib *IntraBlock) IsPartial() bool {
 	if ib.Skip > 0 || ib.Length < ib.fs.plainBS {
 		return true
 	}
@@ -26,17 +26,17 @@ func (ib *intraBlock) IsPartial() bool {
 }
 
 // BlockCipherOff returns the ciphertext offset corresponding to BlockNo
-func (ib *intraBlock) BlockCipherOff() (offset uint64) {
+func (ib *IntraBlock) BlockCipherOff() (offset uint64) {
 	return ib.fs.BlockNoToCipherOff(ib.BlockNo)
 }
 
 // BlockPlainOff returns the plaintext offset corresponding to BlockNo
-func (ib *intraBlock) BlockPlainOff() (offset uint64) {
+func (ib *IntraBlock) BlockPlainOff() (offset uint64) {
 	return ib.fs.BlockNoToPlainOff(ib.BlockNo)
 }
 
 // CropBlock - crop a potentially larger plaintext block down to the relevant part
-func (ib *intraBlock) CropBlock(d []byte) []byte {
+func (ib *IntraBlock) CropBlock(d []byte) []byte {
 	lenHave := len(d)
 	lenWant := int(ib.Skip + ib.Length)
 	if lenHave < lenWant {
@@ -45,8 +45,9 @@ func (ib *intraBlock) CropBlock(d []byte) []byte {
 	return d[ib.Skip:lenWant]
 }
 
-// Ciphertext range corresponding to the sum of all "blocks" (complete blocks)
-func (ib *intraBlock) JointCiphertextRange(blocks []intraBlock) (offset uint64, length uint64) {
+// JointCiphertextRange is the ciphertext range corresponding to the sum of all
+// "blocks" (complete blocks)
+func (ib *IntraBlock) JointCiphertextRange(blocks []IntraBlock) (offset uint64, length uint64) {
 	firstBlock := blocks[0]
 	lastBlock := blocks[len(blocks)-1]
 
@@ -57,8 +58,9 @@ func (ib *intraBlock) JointCiphertextRange(blocks []intraBlock) (offset uint64, 
 	return offset, length
 }
 
-// Plaintext range corresponding to the sum of all "blocks" (complete blocks)
-func JointPlaintextRange(blocks []intraBlock) (offset uint64, length uint64) {
+// JointPlaintextRange is the plaintext range corresponding to the sum of all
+// "blocks" (complete blocks)
+func JointPlaintextRange(blocks []IntraBlock) (offset uint64, length uint64) {
 	firstBlock := blocks[0]
 	lastBlock := blocks[len(blocks)-1]
 

--- a/internal/contentenc/offsets.go
+++ b/internal/contentenc/offsets.go
@@ -8,43 +8,43 @@ import (
 
 // Contentenc methods that translate offsets between ciphertext and plaintext
 
-// get the block number at plain-text offset
+// PlainOffToBlockNo converts a plaintext offset to the ciphertext block number.
 func (be *ContentEnc) PlainOffToBlockNo(plainOffset uint64) uint64 {
 	return plainOffset / be.plainBS
 }
 
-// get the block number at cipher-text offset
+// CipherOffToBlockNo converts the ciphertext offset to the plaintext block number.
 func (be *ContentEnc) CipherOffToBlockNo(cipherOffset uint64) uint64 {
-	if cipherOffset < HEADER_LEN {
+	if cipherOffset < HeaderLen {
 		log.Panicf("BUG: offset %d is inside the file header", cipherOffset)
 	}
-	return (cipherOffset - HEADER_LEN) / be.cipherBS
+	return (cipherOffset - HeaderLen) / be.cipherBS
 }
 
-// get ciphertext offset of block "blockNo"
+// BlockNoToCipherOff gets the ciphertext offset of block "blockNo"
 func (be *ContentEnc) BlockNoToCipherOff(blockNo uint64) uint64 {
-	return HEADER_LEN + blockNo*be.cipherBS
+	return HeaderLen + blockNo*be.cipherBS
 }
 
-// get plaintext offset of block "blockNo"
+// BlockNoToPlainOff gets the plaintext offset of block "blockNo"
 func (be *ContentEnc) BlockNoToPlainOff(blockNo uint64) uint64 {
 	return blockNo * be.plainBS
 }
 
-// PlainSize - calculate plaintext size from ciphertext size
+// CipherSizeToPlainSize calculates the plaintext size from a ciphertext size
 func (be *ContentEnc) CipherSizeToPlainSize(cipherSize uint64) uint64 {
 	// Zero-sized files stay zero-sized
 	if cipherSize == 0 {
 		return 0
 	}
 
-	if cipherSize == HEADER_LEN {
+	if cipherSize == HeaderLen {
 		tlog.Warn.Printf("cipherSize %d == header size: interrupted write?\n", cipherSize)
 		return 0
 	}
 
-	if cipherSize < HEADER_LEN {
-		tlog.Warn.Printf("cipherSize %d < header size %d: corrupt file\n", cipherSize, HEADER_LEN)
+	if cipherSize < HeaderLen {
+		tlog.Warn.Printf("cipherSize %d < header size %d: corrupt file\n", cipherSize, HeaderLen)
 		return 0
 	}
 
@@ -52,12 +52,12 @@ func (be *ContentEnc) CipherSizeToPlainSize(cipherSize uint64) uint64 {
 	blockNo := be.CipherOffToBlockNo(cipherSize - 1)
 	blockCount := blockNo + 1
 
-	overhead := be.BlockOverhead()*blockCount + HEADER_LEN
+	overhead := be.BlockOverhead()*blockCount + HeaderLen
 
 	return cipherSize - overhead
 }
 
-// CipherSize - calculate ciphertext size from plaintext size
+// PlainSizeToCipherSize calculates the ciphertext size from a plaintext size
 func (be *ContentEnc) PlainSizeToCipherSize(plainSize uint64) uint64 {
 	// Zero-sized files stay zero-sized
 	if plainSize == 0 {
@@ -68,16 +68,16 @@ func (be *ContentEnc) PlainSizeToCipherSize(plainSize uint64) uint64 {
 	blockNo := be.PlainOffToBlockNo(plainSize - 1)
 	blockCount := blockNo + 1
 
-	overhead := be.BlockOverhead()*blockCount + HEADER_LEN
+	overhead := be.BlockOverhead()*blockCount + HeaderLen
 
 	return plainSize + overhead
 }
 
-// Split a plaintext byte range into (possibly partial) blocks
+// ExplodePlainRange splits a plaintext byte range into (possibly partial) blocks
 // Returns an empty slice if length == 0.
-func (be *ContentEnc) ExplodePlainRange(offset uint64, length uint64) []intraBlock {
-	var blocks []intraBlock
-	var nextBlock intraBlock
+func (be *ContentEnc) ExplodePlainRange(offset uint64, length uint64) []IntraBlock {
+	var blocks []IntraBlock
+	var nextBlock IntraBlock
 	nextBlock.fs = be
 
 	for length > 0 {
@@ -94,11 +94,11 @@ func (be *ContentEnc) ExplodePlainRange(offset uint64, length uint64) []intraBlo
 	return blocks
 }
 
-// Split a ciphertext byte range into (possibly partial) blocks
-// This is used in reverse mode when reading files
-func (be *ContentEnc) ExplodeCipherRange(offset uint64, length uint64) []intraBlock {
-	var blocks []intraBlock
-	var nextBlock intraBlock
+// ExplodeCipherRange splits a ciphertext byte range into (possibly partial)
+// blocks This is used in reverse mode when reading files
+func (be *ContentEnc) ExplodeCipherRange(offset uint64, length uint64) []IntraBlock {
+	var blocks []IntraBlock
+	var nextBlock IntraBlock
 	nextBlock.fs = be
 
 	for length > 0 {
@@ -120,10 +120,12 @@ func (be *ContentEnc) ExplodeCipherRange(offset uint64, length uint64) []intraBl
 	return blocks
 }
 
+// BlockOverhead returns the per-block overhead.
 func (be *ContentEnc) BlockOverhead() uint64 {
 	return be.cipherBS - be.plainBS
 }
 
+// MinUint64 returns the minimum of two uint64 values.
 func MinUint64(x uint64, y uint64) uint64 {
 	if x < y {
 		return x

--- a/internal/cryptocore/cryptocore.go
+++ b/internal/cryptocore/cryptocore.go
@@ -11,18 +11,25 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/stupidgcm"
 )
 
+// BackendTypeEnum indicates the type of backend in use.
 type BackendTypeEnum int
 
 const (
-	KeyLen     = 32 // AES-256
+	// KeyLen is the cipher key length in bytes.  32 for AES-256.
+	KeyLen = 32
+	// AuthTagLen is the length of a GCM auth tag in bytes.
 	AuthTagLen = 16
 
-	_                              = iota // Skip zero
+	_ = iota // Skip zero
+	// BackendOpenSSL specifies the OpenSSL backend.
 	BackendOpenSSL BackendTypeEnum = iota
-	BackendGoGCM   BackendTypeEnum = iota
-	BackendAESSIV  BackendTypeEnum = iota
+	// BackendGoGCM specifies the Go based GCM backend.
+	BackendGoGCM BackendTypeEnum = iota
+	// BackendAESSIV specifies an AESSIV backend.
+	BackendAESSIV BackendTypeEnum = iota
 )
 
+// CryptoCore is the low level crypto implementation.
 type CryptoCore struct {
 	// AES-256 block cipher. This is used for EME filename encryption.
 	BlockCipher cipher.Block
@@ -35,7 +42,7 @@ type CryptoCore struct {
 	IVLen       int
 }
 
-// "New" returns a new CryptoCore object or panics.
+// New returns a new CryptoCore object or panics.
 //
 // Even though the "GCMIV128" feature flag is now mandatory, we must still
 // support 96-bit IVs here because they are used for encrypting the master

--- a/internal/cryptocore/nonce.go
+++ b/internal/cryptocore/nonce.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/tlog"
 )
 
-// Get "n" random bytes from /dev/urandom or panic
+// RandBytes gets "n" random bytes from /dev/urandom or panic
 func RandBytes(n int) []byte {
 	b := make([]byte, n)
 	_, err := rand.Read(b)
@@ -20,7 +20,7 @@ func RandBytes(n int) []byte {
 	return b
 }
 
-// Return a secure random uint64
+// RandUint64 returns a secure random uint64
 func RandUint64() uint64 {
 	b := RandBytes(8)
 	return binary.BigEndian.Uint64(b)

--- a/internal/fusefrontend/args.go
+++ b/internal/fusefrontend/args.go
@@ -4,7 +4,7 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/cryptocore"
 )
 
-// Container for arguments that are passed from main() to fusefrontend
+// Args is a container for arguments that are passed from main() to fusefrontend
 type Args struct {
 	Masterkey      []byte
 	Cipherdir      string

--- a/internal/fusefrontend/file_allocate_truncate.go
+++ b/internal/fusefrontend/file_allocate_truncate.go
@@ -14,19 +14,22 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/tlog"
 )
 
-const FALLOC_DEFAULT = 0x00
-const FALLOC_FL_KEEP_SIZE = 0x01
+// FallocDefault uses truncate to allocate file storage.
+const FallocDefault = 0x00
+
+// FallocFLKeepSize is a direct implementation of file allocation.
+const FallocFLKeepSize = 0x01
 
 // Only warn once
 var allocateWarnOnce sync.Once
 
 // Allocate - FUSE call for fallocate(2)
 //
-// mode=FALLOC_FL_KEEP_SIZE is implemented directly.
+// mode=FallocFLKeepSize is implemented directly.
 //
-// mode=FALLOC_DEFAULT is implemented as a two-step process:
+// mode=FallocDefault is implemented as a two-step process:
 //
-//   (1) Allocate the space using FALLOC_FL_KEEP_SIZE
+//   (1) Allocate the space using FallocFLKeepSize
 //   (2) Set the file size using ftruncate (via truncateGrowFile)
 //
 // This allows us to reuse the file grow mechanics from Truncate as they are
@@ -34,7 +37,7 @@ var allocateWarnOnce sync.Once
 //
 // Other modes (hole punching, zeroing) are not supported.
 func (f *file) Allocate(off uint64, sz uint64, mode uint32) fuse.Status {
-	if mode != FALLOC_DEFAULT && mode != FALLOC_FL_KEEP_SIZE {
+	if mode != FallocDefault && mode != FallocFLKeepSize {
 		f := func() {
 			tlog.Warn.Print("fallocate: only mode 0 (default) and 1 (keep size) are supported")
 		}
@@ -54,19 +57,19 @@ func (f *file) Allocate(off uint64, sz uint64, mode uint32) fuse.Status {
 	firstBlock := blocks[0]
 	lastBlock := blocks[len(blocks)-1]
 
-	// Step (1): Allocate the space the user wants using FALLOC_FL_KEEP_SIZE.
+	// Step (1): Allocate the space the user wants using FallocFLKeepSize.
 	// This will fill file holes and/or allocate additional space past the end of
 	// the file.
 	cipherOff := firstBlock.BlockCipherOff()
 	cipherSz := lastBlock.BlockCipherOff() - cipherOff +
 		f.contentEnc.PlainSizeToCipherSize(lastBlock.Skip+lastBlock.Length)
-	err := syscallcompat.Fallocate(f.intFd(), FALLOC_FL_KEEP_SIZE, int64(cipherOff), int64(cipherSz))
+	err := syscallcompat.Fallocate(f.intFd(), FallocFLKeepSize, int64(cipherOff), int64(cipherSz))
 	tlog.Debug.Printf("Allocate off=%d sz=%d mode=%x cipherOff=%d cipherSz=%d\n",
 		off, sz, mode, cipherOff, cipherSz)
 	if err != nil {
 		return fuse.ToStatus(err)
 	}
-	if mode == FALLOC_FL_KEEP_SIZE {
+	if mode == FallocFLKeepSize {
 		// The user did not want to change the apparent size. We are done.
 		return fuse.OK
 	}
@@ -116,11 +119,12 @@ func (f *file) Truncate(newSize uint64) fuse.Status {
 	oldSize, err := f.statPlainSize()
 	if err != nil {
 		return fuse.ToStatus(err)
-	} else {
-		oldB := float32(oldSize) / float32(f.contentEnc.PlainBS())
-		newB := float32(newSize) / float32(f.contentEnc.PlainBS())
-		tlog.Debug.Printf("ino%d: FUSE Truncate from %.2f to %.2f blocks (%d to %d bytes)", f.ino, oldB, newB, oldSize, newSize)
 	}
+
+	oldB := float32(oldSize) / float32(f.contentEnc.PlainBS())
+	newB := float32(newSize) / float32(f.contentEnc.PlainBS())
+	tlog.Debug.Printf("ino%d: FUSE Truncate from %.2f to %.2f blocks (%d to %d bytes)", f.ino, oldB, newB, oldSize, newSize)
+
 	// File size stays the same - nothing to do
 	if newSize == oldSize {
 		return fuse.OK
@@ -128,34 +132,34 @@ func (f *file) Truncate(newSize uint64) fuse.Status {
 	// File grows
 	if newSize > oldSize {
 		return f.truncateGrowFile(oldSize, newSize)
-	} else {
-		// File shrinks
-		blockNo := f.contentEnc.PlainOffToBlockNo(newSize)
-		cipherOff := f.contentEnc.BlockNoToCipherOff(blockNo)
-		plainOff := f.contentEnc.BlockNoToPlainOff(blockNo)
-		lastBlockLen := newSize - plainOff
-		var data []byte
-		if lastBlockLen > 0 {
-			var status fuse.Status
-			data, status = f.doRead(plainOff, lastBlockLen)
-			if status != fuse.OK {
-				tlog.Warn.Printf("Truncate: shrink doRead returned error: %v", err)
-				return status
-			}
-		}
-		// Truncate down to the last complete block
-		err = syscall.Ftruncate(int(f.fd.Fd()), int64(cipherOff))
-		if err != nil {
-			tlog.Warn.Printf("Truncate: shrink Ftruncate returned error: %v", err)
-			return fuse.ToStatus(err)
-		}
-		// Append partial block
-		if lastBlockLen > 0 {
-			_, status := f.doWrite(data, int64(plainOff))
+	}
+
+	// File shrinks
+	blockNo := f.contentEnc.PlainOffToBlockNo(newSize)
+	cipherOff := f.contentEnc.BlockNoToCipherOff(blockNo)
+	plainOff := f.contentEnc.BlockNoToPlainOff(blockNo)
+	lastBlockLen := newSize - plainOff
+	var data []byte
+	if lastBlockLen > 0 {
+		var status fuse.Status
+		data, status = f.doRead(plainOff, lastBlockLen)
+		if status != fuse.OK {
+			tlog.Warn.Printf("Truncate: shrink doRead returned error: %v", err)
 			return status
 		}
-		return fuse.OK
 	}
+	// Truncate down to the last complete block
+	err = syscall.Ftruncate(int(f.fd.Fd()), int64(cipherOff))
+	if err != nil {
+		tlog.Warn.Printf("Truncate: shrink Ftruncate returned error: %v", err)
+		return fuse.ToStatus(err)
+	}
+	// Append partial block
+	if lastBlockLen > 0 {
+		_, status := f.doWrite(data, int64(plainOff))
+		return status
+	}
+	return fuse.OK
 }
 
 // statPlainSize stats the file and returns the plaintext size
@@ -198,12 +202,12 @@ func (f *file) truncateGrowFile(oldPlainSz uint64, newPlainSz uint64) fuse.Statu
 		off := lastBlock.BlockPlainOff()
 		_, status := f.doWrite(make([]byte, lastBlock.Length), int64(off+lastBlock.Skip))
 		return status
-	} else {
-		off := lastBlock.BlockCipherOff()
-		err = syscall.Ftruncate(f.intFd(), int64(off+f.contentEnc.CipherBS()))
-		if err != nil {
-			tlog.Warn.Printf("Truncate: grow Ftruncate returned error: %v", err)
-		}
-		return fuse.ToStatus(err)
 	}
+
+	off := lastBlock.BlockCipherOff()
+	err = syscall.Ftruncate(f.intFd(), int64(off+f.contentEnc.CipherBS()))
+	if err != nil {
+		tlog.Warn.Printf("Truncate: grow Ftruncate returned error: %v", err)
+	}
+	return fuse.ToStatus(err)
 }

--- a/internal/fusefrontend/fs_dir.go
+++ b/internal/fusefrontend/fs_dir.go
@@ -40,6 +40,7 @@ func (fs *FS) mkdirWithIv(cPath string, mode uint32) error {
 	return err
 }
 
+// Mkdir implements pathfs.FileSystem
 func (fs *FS) Mkdir(newPath string, mode uint32, context *fuse.Context) (code fuse.Status) {
 	if fs.isFiltered(newPath) {
 		return fuse.EPERM
@@ -97,6 +98,7 @@ func (fs *FS) Mkdir(newPath string, mode uint32, context *fuse.Context) (code fu
 	return fuse.OK
 }
 
+// Rmdir implements pathfs.FileSystem
 func (fs *FS) Rmdir(path string, context *fuse.Context) (code fuse.Status) {
 	cPath, err := fs.getBackingPath(path)
 	if err != nil {
@@ -215,6 +217,7 @@ func (fs *FS) Rmdir(path string, context *fuse.Context) (code fuse.Status) {
 	return fuse.OK
 }
 
+// OpenDir implements pathfs.FileSystem
 func (fs *FS) OpenDir(dirName string, context *fuse.Context) ([]fuse.DirEntry, fuse.Status) {
 	tlog.Debug.Printf("OpenDir(%s)", dirName)
 	cDirName, err := fs.encryptPath(dirName)

--- a/internal/fusefrontend_reverse/ino_map.go
+++ b/internal/fusefrontend_reverse/ino_map.go
@@ -4,7 +4,7 @@ import (
 	"sync/atomic"
 )
 
-func NewInoGen() *inoGenT {
+func newInoGen() *inoGenT {
 	var ino uint64 = 1
 	return &inoGenT{&ino}
 }

--- a/internal/fusefrontend_reverse/reverse_longnames.go
+++ b/internal/fusefrontend_reverse/reverse_longnames.go
@@ -70,9 +70,9 @@ func (rfs *reverseFS) findLongnameParent(dir string, dirIV []byte, longname stri
 	}
 	if hit == "" {
 		return "", syscall.ENOENT
-	} else {
-		return hit, nil
 	}
+
+	return hit, nil
 }
 
 func (rfs *reverseFS) newNameFile(relPath string) (nodefs.File, fuse.Status) {

--- a/internal/fusefrontend_reverse/rfs.go
+++ b/internal/fusefrontend_reverse/rfs.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	// DirIVMode is the mode to use for Dir IV files.
 	DirIVMode = syscall.S_IFREG | 0400
 )
 
@@ -42,8 +43,10 @@ type reverseFS struct {
 	inoMapLock sync.Mutex
 }
 
-// Encrypted FUSE overlay filesystem
-func NewFS(args fusefrontend.Args) *reverseFS {
+var _ pathfs.FileSystem = &reverseFS{}
+
+// NewFS returns an encrypted FUSE overlay filesystem
+func NewFS(args fusefrontend.Args) pathfs.FileSystem {
 	cryptoCore := cryptocore.New(args.Masterkey, args.CryptoBackend, contentenc.DefaultIVBits)
 	contentEnc := contentenc.New(cryptoCore, contentenc.DefaultBS)
 	nameTransform := nametransform.New(cryptoCore, args.LongNames)
@@ -55,7 +58,7 @@ func NewFS(args fusefrontend.Args) *reverseFS {
 		args:          args,
 		nameTransform: nameTransform,
 		contentEnc:    contentEnc,
-		inoGen:        NewInoGen(),
+		inoGen:        newInoGen(),
 		inoMap:        map[devIno]uint64{},
 	}
 }

--- a/internal/nametransform/diriv.go
+++ b/internal/nametransform/diriv.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	// identical to AES block size
+	// DirIVLen is identical to AES block size
 	DirIVLen = 16
-	// dirIV is stored in this file. Exported because we have to ignore this
-	// name in directory listing.
+	// DirIVFilename is the filename used to store directory IV.
+	// Exported because we have to ignore this name in directory listing.
 	DirIVFilename = "gocryptfs.diriv"
 )
 

--- a/internal/nametransform/longnames.go
+++ b/internal/nametransform/longnames.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	// LongNameSuffix is the suffix used for files with long names.
 	// Files with long names are stored in two files:
 	// gocryptfs.longname.[sha256]       <--- File content, prefix = gocryptfs.longname.
 	// gocryptfs.longname.[sha256].name  <--- File name, suffix = .name
@@ -31,12 +32,13 @@ func HashLongName(name string) string {
 
 // Values returned by IsLongName
 const (
-	// File that stores the file content.
+	// LongNameContent is the file that stores the file content.
 	// Example: gocryptfs.longname.URrM8kgxTKYMgCk4hKk7RO9Lcfr30XQof4L_5bD9Iro=
 	LongNameContent = iota
-	// File that stores the full encrypted filename.
+	// LongNameFilename is the file that stores the full encrypted filename.
 	// Example: gocryptfs.longname.URrM8kgxTKYMgCk4hKk7RO9Lcfr30XQof4L_5bD9Iro=.name
 	LongNameFilename = iota
+	// LongNameNone is used when the file does not have a long name.
 	// Example: i1bpTaVLZq7sRNA9mL_2Ig==
 	LongNameNone = iota
 )

--- a/internal/nametransform/names.go
+++ b/internal/nametransform/names.go
@@ -1,4 +1,4 @@
-// Package namtransforms encrypts and decrypts filenames.
+// Package nametransform encrypts and decrypts filenames.
 package nametransform
 
 import (
@@ -12,12 +12,14 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/tlog"
 )
 
+// NameTransform is used to transform filenames.
 type NameTransform struct {
 	cryptoCore *cryptocore.CryptoCore
 	longNames  bool
 	DirIVCache dirIVCache
 }
 
+// New returns a new NameTransform instance.
 func New(c *cryptocore.CryptoCore, longNames bool) *NameTransform {
 	return &NameTransform{
 		cryptoCore: c,
@@ -51,7 +53,7 @@ func (n *NameTransform) DecryptName(cipherName string, iv []byte) (string, error
 	return plain, err
 }
 
-// encryptName - encrypt "plainName", return base64-encoded "cipherName64".
+// EncryptName encrypts "plainName", returns a base64-encoded "cipherName64".
 // Used internally by EncryptPathDirIV().
 // The encryption is either CBC or EME, depending on "useEME".
 //

--- a/internal/prefer_openssl/prefer_go1.5.go
+++ b/internal/prefer_openssl/prefer_go1.5.go
@@ -1,4 +1,4 @@
-// +build !go1.6,!go1.7 !amd64
+// +build !go1.6 !amd64
 // not go1.6+ OR not amd64
 
 package prefer_openssl

--- a/internal/prefer_openssl/prefer_go1.5.go
+++ b/internal/prefer_openssl/prefer_go1.5.go
@@ -1,8 +1,9 @@
-// +build !go1.6 !amd64
+// +build !go1.6,!go1.7 !amd64
 // not go1.6+ OR not amd64
 
 package prefer_openssl
 
+// PreferOpenSSL returns true if OpenSSL should be used.
 func PreferOpenSSL() bool {
 	// OpenSSL is always faster than Go GCM on old Go versions or on anything
 	// other than amd64

--- a/internal/prefer_openssl/prefer_go1.6.go
+++ b/internal/prefer_openssl/prefer_go1.6.go
@@ -1,4 +1,4 @@
-// +build go1.6,amd64
+// +build go1.7,amd64 go1.6,amd64
 // go1.6+ AND amd64
 
 package prefer_openssl

--- a/internal/prefer_openssl/prefer_go1.6.go
+++ b/internal/prefer_openssl/prefer_go1.6.go
@@ -1,4 +1,4 @@
-// +build go1.7,amd64 go1.6,amd64
+// +build go1.6,amd64
 // go1.6+ AND amd64
 
 package prefer_openssl

--- a/internal/readpassword/read.go
+++ b/internal/readpassword/read.go
@@ -17,8 +17,8 @@ const (
 	exitCode = 9
 )
 
-// Once() tries to get a password from the user, either from the terminal,
-// extpass or stdin.
+// Once tries to get a password from the user, either from the terminal, extpass
+// or stdin.
 func Once(extpass string) string {
 	if extpass != "" {
 		return readPasswordExtpass(extpass)
@@ -29,8 +29,8 @@ func Once(extpass string) string {
 	return readPasswordTerminal("Password: ")
 }
 
-// Twice() is the same as Once but will prompt twice if we get
-// the password from the terminal.
+// Twice is the same as Once but will prompt twice if we get the password from
+// the terminal.
 func Twice(extpass string) string {
 	if extpass != "" {
 		return readPasswordExtpass(extpass)

--- a/internal/siv_aead/siv_aead.go
+++ b/internal/siv_aead/siv_aead.go
@@ -3,6 +3,8 @@
 package siv_aead
 
 import (
+	"crypto/cipher"
+
 	"github.com/jacobsa/crypto/siv"
 )
 
@@ -10,7 +12,10 @@ type sivAead struct {
 	key []byte
 }
 
-func New(key []byte) *sivAead {
+var _ cipher.AEAD = &sivAead{}
+
+// New returns a new cipher.AEAD implementation.
+func New(key []byte) cipher.AEAD {
 	return &sivAead{
 		key: key,
 	}
@@ -29,7 +34,7 @@ func (s *sivAead) Overhead() int {
 
 }
 
-// Seal - encrypt "in" using "nonce" and "authData" and append the result to "dst"
+// Seal encrypts "in" using "nonce" and "authData" and append the result to "dst"
 func (s *sivAead) Seal(dst, nonce, plaintext, authData []byte) []byte {
 	if len(nonce) != 16 {
 		// SIV supports any nonce size, but in gocryptfs we exclusively use 16.
@@ -47,7 +52,7 @@ func (s *sivAead) Seal(dst, nonce, plaintext, authData []byte) []byte {
 	return out
 }
 
-// Open - decrypt "in" using "nonce" and "authData" and append the result to "dst"
+// Open decrypts "in" using "nonce" and "authData" and append the result to "dst"
 func (s *sivAead) Open(dst, nonce, ciphertext, authData []byte) ([]byte, error) {
 	if len(nonce) != 16 {
 		// SIV supports any nonce size, but in gocryptfs we exclusively use 16.

--- a/internal/stupidgcm/stupidgcm.go
+++ b/internal/stupidgcm/stupidgcm.go
@@ -7,6 +7,7 @@ package stupidgcm
 import "C"
 
 import (
+	"crypto/cipher"
 	"fmt"
 	"log"
 	"unsafe"
@@ -23,7 +24,10 @@ type stupidGCM struct {
 	key []byte
 }
 
-func New(key []byte) stupidGCM {
+var _ cipher.AEAD = &stupidGCM{}
+
+// New returns a new cipher.AEAD implementation..
+func New(key []byte) cipher.AEAD {
 	if len(key) != keyLen {
 		log.Panicf("Only %d-byte keys are supported", keyLen)
 	}
@@ -38,7 +42,7 @@ func (g stupidGCM) Overhead() int {
 	return tagLen
 }
 
-// Seal - encrypt "in" using "iv" and "authData" and append the result to "dst"
+// Seal encrypts "in" using "iv" and "authData" and append the result to "dst"
 func (g stupidGCM) Seal(dst, iv, in, authData []byte) []byte {
 	if len(iv) != ivLen {
 		log.Panicf("Only %d-byte IVs are supported", ivLen)
@@ -109,7 +113,7 @@ func (g stupidGCM) Seal(dst, iv, in, authData []byte) []byte {
 	return append(dst, buf...)
 }
 
-// Open - decrypt "in" using "iv" and "authData" and append the result to "dst"
+// Open decrypts "in" using "iv" and "authData" and append the result to "dst"
 func (g stupidGCM) Open(dst, iv, in, authData []byte) ([]byte, error) {
 	if len(iv) != ivLen {
 		log.Panicf("Only %d-byte IVs are supported", ivLen)

--- a/internal/syscallcompat/sys_linux.go
+++ b/internal/syscallcompat/sys_linux.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/tlog"
 )
 
-const fAllocFLKeepSize = 0x01
+const FALLOC_FL_KEEP_SIZE = 0x01
 
 var preallocWarn sync.Once
 
@@ -17,7 +17,7 @@ var preallocWarn sync.Once
 // ciphertext block (that would corrupt the block).
 func EnospcPrealloc(fd int, off int64, len int64) (err error) {
 	for {
-		err = syscall.Fallocate(fd, fAllocFLKeepSize, off, len)
+		err = syscall.Fallocate(fd, FALLOC_FL_KEEP_SIZE, off, len)
 		if err == syscall.EINTR {
 			// fallocate, like many syscalls, can return EINTR. This is not an
 			// error and just signifies that the operation was interrupted by a

--- a/internal/syscallcompat/sys_linux.go
+++ b/internal/syscallcompat/sys_linux.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/tlog"
 )
 
-const FALLOC_FL_KEEP_SIZE = 0x01
+const fAllocFLKeepSize = 0x01
 
 var preallocWarn sync.Once
 
@@ -17,7 +17,7 @@ var preallocWarn sync.Once
 // ciphertext block (that would corrupt the block).
 func EnospcPrealloc(fd int, off int64, len int64) (err error) {
 	for {
-		err = syscall.Fallocate(fd, FALLOC_FL_KEEP_SIZE, off, len)
+		err = syscall.Fallocate(fd, fAllocFLKeepSize, off, len)
 		if err == syscall.EINTR {
 			// fallocate, like many syscalls, can return EINTR. This is not an
 			// error and just signifies that the operation was interrupted by a
@@ -38,22 +38,27 @@ func EnospcPrealloc(fd int, off int64, len int64) (err error) {
 	}
 }
 
+// Fallocate wraps the Fallocate syscall.
 func Fallocate(fd int, mode uint32, off int64, len int64) (err error) {
 	return syscall.Fallocate(fd, mode, off, len)
 }
 
+// Openat wraps the Fallocate syscall.
 func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error) {
 	return syscall.Openat(dirfd, path, flags, mode)
 }
 
+// Renameat wraps the Fallocate syscall.
 func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err error) {
 	return syscall.Renameat(olddirfd, oldpath, newdirfd, newpath)
 }
 
+// Unlinkat wraps the Fallocate syscall.
 func Unlinkat(dirfd int, path string) error {
 	return syscall.Unlinkat(dirfd, path)
 }
 
+// Mknodat wraps the Fallocate syscall.
 func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
 	return syscall.Mknodat(dirfd, path, mode, dev)
 }

--- a/internal/tlog/log.go
+++ b/internal/tlog/log.go
@@ -12,21 +12,34 @@ import (
 )
 
 const (
+	// ProgramName is used in log reports.
 	ProgramName = "gocryptfs"
 	wpanicMsg   = "-wpanic turns this warning into a panic: "
 )
 
 // Escape sequences for terminal colors. These will be empty strings if stdout
 // is not a terminal.
-var ColorReset, ColorGrey, ColorRed, ColorGreen, ColorYellow string
+var (
+	// ColorReset is used to reset terminal colors.
+	ColorReset string
+	// ColorGrey is a terminal color setting string.
+	ColorGrey string
+	// ColorRed is a terminal color setting string.
+	ColorRed string
+	// ColorGreen is a terminal color setting string.
+	ColorGreen string
+	// ColorYellow is a terminal color setting string.
+	ColorYellow string
+)
 
+// JSONDump writes the object in json form.
 func JSONDump(obj interface{}) string {
 	b, err := json.MarshalIndent(obj, "", "\t")
 	if err != nil {
 		return err.Error()
-	} else {
-		return string(b)
 	}
+
+	return string(b)
 }
 
 // toggledLogger - a Logger than can be enabled and disabled

--- a/main.go
+++ b/main.go
@@ -313,7 +313,7 @@ func initFuseFrontend(key []byte, args argContainer, confFile *configfile.ConfFi
 	}
 	// If allow_other is set and we run as root, try to give newly created files to
 	// the right user.
-	if args.allowOther && os.Getuid() == 0 {
+	if args.allow_other && os.Getuid() == 0 {
 		frontendArgs.PreserveOwner = true
 	}
 	jsonBytes, _ := json.MarshalIndent(frontendArgs, "", "\t")
@@ -336,7 +336,7 @@ func initFuseFrontend(key []byte, args argContainer, confFile *configfile.ConfFi
 	conn := nodefs.NewFileSystemConnector(pathFs.Root(), fuseOpts)
 	var mOpts fuse.MountOptions
 	mOpts.AllowOther = false
-	if args.allowOther {
+	if args.allow_other {
 		tlog.Info.Printf(tlog.ColorYellow + "The option \"-allow_other\" is set. Make sure the file " +
 			"permissions protect your data from unwanted access." + tlog.ColorReset)
 		mOpts.AllowOther = true

--- a/main.go
+++ b/main.go
@@ -28,25 +28,25 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/tlog"
 )
 
+// Exit codes
 const (
-	// Exit codes
-	ERREXIT_USAGE      = 1
-	ERREXIT_MOUNT      = 3
-	ERREXIT_CIPHERDIR  = 6
-	ERREXIT_INIT       = 7
-	ERREXIT_LOADCONF   = 8
-	ERREXIT_MOUNTPOINT = 10
+	ErrExitUsage      = 1
+	ErrExitMount      = 3
+	ErrExitCipherDir  = 6
+	ErrExitInit       = 7
+	ErrExitLoadConf   = 8
+	ErrExitMountPoint = 10
 )
 
 const pleaseBuildBash = "[not set - please compile using ./build.bash]"
 
-// gocryptfs version according to git, set by build.bash
+// GitVersion is the gocryptfs version according to git, set by build.bash
 var GitVersion = pleaseBuildBash
 
-// go-fuse library version, set by build.bash
+// GitVersionFuse is the go-fuse library version, set by build.bash
 var GitVersionFuse = pleaseBuildBash
 
-// Unix timestamp, set by build.bash
+// BuildTime is the Unix timestamp, set by build.bash
 var BuildTime = "0"
 
 func usageText() {
@@ -67,14 +67,14 @@ func loadConfig(args *argContainer) (masterkey []byte, confFile *configfile.Conf
 	_, err := os.Stat(args.config)
 	if err != nil {
 		tlog.Fatal.Printf("Config file not found: %v", err)
-		os.Exit(ERREXIT_LOADCONF)
+		os.Exit(ErrExitLoadConf)
 	}
 	pw := readpassword.Once(args.extpass)
 	tlog.Info.Println("Decrypting master key")
 	masterkey, confFile, err = configfile.LoadConfFile(args.config, pw)
 	if err != nil {
 		tlog.Fatal.Println(err)
-		os.Exit(ERREXIT_LOADCONF)
+		os.Exit(ErrExitLoadConf)
 	}
 
 	return masterkey, confFile
@@ -89,7 +89,7 @@ func changePassword(args *argContainer) {
 	err := confFile.WriteFile()
 	if err != nil {
 		tlog.Fatal.Println(err)
-		os.Exit(ERREXIT_INIT)
+		os.Exit(ErrExitInit)
 	}
 	tlog.Info.Printf("Password changed.")
 	os.Exit(0)
@@ -140,11 +140,11 @@ func main() {
 		err = checkDir(args.cipherdir)
 		if err != nil {
 			tlog.Fatal.Printf("Invalid cipherdir: %v", err)
-			os.Exit(ERREXIT_CIPHERDIR)
+			os.Exit(ErrExitCipherDir)
 		}
 	} else {
 		usageText()
-		os.Exit(ERREXIT_USAGE)
+		os.Exit(ErrExitUsage)
 	}
 	// "-q"
 	if args.quiet {
@@ -159,7 +159,7 @@ func main() {
 		args.config, err = filepath.Abs(args.config)
 		if err != nil {
 			tlog.Fatal.Printf("Invalid \"-config\" setting: %v", err)
-			os.Exit(ERREXIT_INIT)
+			os.Exit(ErrExitInit)
 		}
 		tlog.Info.Printf("Using config file at custom location %s", args.config)
 	} else if args.reverse {
@@ -174,7 +174,7 @@ func main() {
 		f, err = os.Create(args.cpuprofile)
 		if err != nil {
 			tlog.Fatal.Println(err)
-			os.Exit(ERREXIT_INIT)
+			os.Exit(ErrExitInit)
 		}
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
@@ -186,7 +186,7 @@ func main() {
 		f, err = os.Create(args.memprofile)
 		if err != nil {
 			tlog.Fatal.Println(err)
-			os.Exit(ERREXIT_INIT)
+			os.Exit(ErrExitInit)
 		}
 		defer func() {
 			pprof.WriteHeapProfile(f)
@@ -208,7 +208,7 @@ func main() {
 	if args.init {
 		if flagSet.NArg() > 1 {
 			tlog.Fatal.Printf("Usage: %s -init [OPTIONS] CIPHERDIR", tlog.ProgramName)
-			os.Exit(ERREXIT_USAGE)
+			os.Exit(ErrExitUsage)
 		}
 		initDir(&args) // does not return
 	}
@@ -216,7 +216,7 @@ func main() {
 	if args.passwd {
 		if flagSet.NArg() > 1 {
 			tlog.Fatal.Printf("Usage: %s -passwd [OPTIONS] CIPHERDIR", tlog.ProgramName)
-			os.Exit(ERREXIT_USAGE)
+			os.Exit(ErrExitUsage)
 		}
 		changePassword(&args) // does not return
 	}
@@ -224,17 +224,17 @@ func main() {
 	// Check mountpoint
 	if flagSet.NArg() != 2 {
 		tlog.Fatal.Printf("Usage: %s [OPTIONS] CIPHERDIR MOUNTPOINT", tlog.ProgramName)
-		os.Exit(ERREXIT_USAGE)
+		os.Exit(ErrExitUsage)
 	}
 	args.mountpoint, err = filepath.Abs(flagSet.Arg(1))
 	if err != nil {
 		tlog.Fatal.Printf("Invalid mountpoint: %v", err)
-		os.Exit(ERREXIT_MOUNTPOINT)
+		os.Exit(ErrExitMountPoint)
 	}
 	err = checkDirEmpty(args.mountpoint)
 	if err != nil {
 		tlog.Fatal.Printf("Invalid mountpoint: %v", err)
-		os.Exit(ERREXIT_MOUNTPOINT)
+		os.Exit(ErrExitMountPoint)
 	}
 	// Get master key
 	var masterkey []byte
@@ -308,12 +308,12 @@ func initFuseFrontend(key []byte, args argContainer, confFile *configfile.ConfFi
 			frontendArgs.CryptoBackend = cryptocore.BackendAESSIV
 		} else if args.reverse {
 			tlog.Fatal.Printf("AES-SIV is required by reverse mode, but not enabled in the config file")
-			os.Exit(ERREXIT_USAGE)
+			os.Exit(ErrExitUsage)
 		}
 	}
 	// If allow_other is set and we run as root, try to give newly created files to
 	// the right user.
-	if args.allow_other && os.Getuid() == 0 {
+	if args.allowOther && os.Getuid() == 0 {
 		frontendArgs.PreserveOwner = true
 	}
 	jsonBytes, _ := json.MarshalIndent(frontendArgs, "", "\t")
@@ -336,7 +336,7 @@ func initFuseFrontend(key []byte, args argContainer, confFile *configfile.ConfFi
 	conn := nodefs.NewFileSystemConnector(pathFs.Root(), fuseOpts)
 	var mOpts fuse.MountOptions
 	mOpts.AllowOther = false
-	if args.allow_other {
+	if args.allowOther {
 		tlog.Info.Printf(tlog.ColorYellow + "The option \"-allow_other\" is set. Make sure the file " +
 			"permissions protect your data from unwanted access." + tlog.ColorReset)
 		mOpts.AllowOther = true
@@ -367,7 +367,7 @@ func initFuseFrontend(key []byte, args argContainer, confFile *configfile.ConfFi
 	srv, err := fuse.NewServer(conn.RawFS(), args.mountpoint, &mOpts)
 	if err != nil {
 		tlog.Fatal.Printf("Mount failed: %v", err)
-		os.Exit(ERREXIT_MOUNT)
+		os.Exit(ErrExitMount)
 	}
 	srv.SetDebug(args.fusedebug)
 

--- a/tests/matrix/matrix_test.go
+++ b/tests/matrix/matrix_test.go
@@ -170,8 +170,8 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
-const FAllocDefault = 0x00
-const FAllocFLKeepSize = 0x01
+const FALLOC_DEFAULT = 0x00
+const FALLOC_FL_KEEP_SIZE = 0x01
 
 func TestFallocate(t *testing.T) {
 	if runtime.GOOS == "darwin" {
@@ -192,7 +192,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate 30 bytes, keep size
 	// gocryptfs ||        (0 blocks)
 	//      ext4 |  d   |  (1 block)
-	err = syscallcompat.Fallocate(fd, FAllocFLKeepSize, 0, 30)
+	err = syscallcompat.Fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 30)
 	if err != nil {
 		t.Error(err)
 	}
@@ -211,7 +211,7 @@ func TestFallocate(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, nBlocks = test_helpers.Du(t, fd)
-	if want := 2; nBlocks/8 != int64(want) {
+	if want, got := int64(2), nBlocks/8; want != got {
 		t.Errorf("Expected %d 4k block(s), got %d", want, nBlocks/8)
 	}
 	if md5 := test_helpers.Md5fn(fn); md5 != "5420afa22f6423a9f59e669540656bb4" {
@@ -220,7 +220,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate the whole file space
 	// gocryptfs |  h   |   h  | d|   (1 block)
 	//      ext4 |  d  |  d  |  d  |  (3 blocks
-	err = syscallcompat.Fallocate(fd, FAllocDefault, 0, 9000)
+	err = syscallcompat.Fallocate(fd, FALLOC_DEFAULT, 0, 9000)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +246,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate 10 bytes in the second block
 	// gocryptfs |  h   |   h  | d|   (1 block)
 	//      ext4 |  d  |  d  |  d  |  (2 blocks)
-	syscallcompat.Fallocate(fd, FAllocDefault, 5000, 10)
+	syscallcompat.Fallocate(fd, FALLOC_DEFAULT, 5000, 10)
 	_, nBlocks = test_helpers.Du(t, fd)
 	if want := 3; nBlocks/8 != int64(want) {
 		t.Errorf("Expected %d 4k block(s), got %d", want, nBlocks/8)
@@ -259,7 +259,7 @@ func TestFallocate(t *testing.T) {
 	// Grow the file to 4 blocks
 	// gocryptfs |  h   |  h   |  d   |d|  (2 blocks)
 	//      ext4 |  d  |  d  |  d  |  d  | (3 blocks)
-	syscallcompat.Fallocate(fd, FAllocDefault, 15000, 10)
+	syscallcompat.Fallocate(fd, FALLOC_DEFAULT, 15000, 10)
 	_, nBlocks = test_helpers.Du(t, fd)
 	if want := 4; nBlocks/8 != int64(want) {
 		t.Errorf("Expected %d 4k block(s), got %d", want, nBlocks/8)
@@ -271,7 +271,7 @@ func TestFallocate(t *testing.T) {
 	// Shrinking a file using fallocate should have no effect
 	for _, off := range []int64{0, 10, 2000, 5000} {
 		for _, sz := range []int64{0, 1, 42, 6000} {
-			syscallcompat.Fallocate(fd, FAllocDefault, off, sz)
+			syscallcompat.Fallocate(fd, FALLOC_DEFAULT, off, sz)
 			test_helpers.VerifySize(t, fn, 15010)
 			if md5 := test_helpers.Md5fn(fn); md5 != "c4c44c7a41ab7798a79d093eb44f99fc" {
 				t.Errorf("Wrong md5 %s", md5)

--- a/tests/matrix/matrix_test.go
+++ b/tests/matrix/matrix_test.go
@@ -170,8 +170,8 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
-const FALLOC_DEFAULT = 0x00
-const FALLOC_FL_KEEP_SIZE = 0x01
+const FAllocDefault = 0x00
+const FAllocFLKeepSize = 0x01
 
 func TestFallocate(t *testing.T) {
 	if runtime.GOOS == "darwin" {
@@ -192,7 +192,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate 30 bytes, keep size
 	// gocryptfs ||        (0 blocks)
 	//      ext4 |  d   |  (1 block)
-	err = syscallcompat.Fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 30)
+	err = syscallcompat.Fallocate(fd, FAllocFLKeepSize, 0, 30)
 	if err != nil {
 		t.Error(err)
 	}
@@ -220,7 +220,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate the whole file space
 	// gocryptfs |  h   |   h  | d|   (1 block)
 	//      ext4 |  d  |  d  |  d  |  (3 blocks
-	err = syscallcompat.Fallocate(fd, FALLOC_DEFAULT, 0, 9000)
+	err = syscallcompat.Fallocate(fd, FAllocDefault, 0, 9000)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +246,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate 10 bytes in the second block
 	// gocryptfs |  h   |   h  | d|   (1 block)
 	//      ext4 |  d  |  d  |  d  |  (2 blocks)
-	syscallcompat.Fallocate(fd, FALLOC_DEFAULT, 5000, 10)
+	syscallcompat.Fallocate(fd, FAllocDefault, 5000, 10)
 	_, nBlocks = test_helpers.Du(t, fd)
 	if want := 3; nBlocks/8 != int64(want) {
 		t.Errorf("Expected %d 4k block(s), got %d", want, nBlocks/8)
@@ -259,7 +259,7 @@ func TestFallocate(t *testing.T) {
 	// Grow the file to 4 blocks
 	// gocryptfs |  h   |  h   |  d   |d|  (2 blocks)
 	//      ext4 |  d  |  d  |  d  |  d  | (3 blocks)
-	syscallcompat.Fallocate(fd, FALLOC_DEFAULT, 15000, 10)
+	syscallcompat.Fallocate(fd, FAllocDefault, 15000, 10)
 	_, nBlocks = test_helpers.Du(t, fd)
 	if want := 4; nBlocks/8 != int64(want) {
 		t.Errorf("Expected %d 4k block(s), got %d", want, nBlocks/8)
@@ -271,7 +271,7 @@ func TestFallocate(t *testing.T) {
 	// Shrinking a file using fallocate should have no effect
 	for _, off := range []int64{0, 10, 2000, 5000} {
 		for _, sz := range []int64{0, 1, 42, 6000} {
-			syscallcompat.Fallocate(fd, FALLOC_DEFAULT, off, sz)
+			syscallcompat.Fallocate(fd, FAllocDefault, off, sz)
 			test_helpers.VerifySize(t, fn, 15010)
 			if md5 := test_helpers.Md5fn(fn); md5 != "c4c44c7a41ab7798a79d093eb44f99fc" {
 				t.Errorf("Wrong md5 %s", md5)

--- a/tests/test_helpers/helpers.go
+++ b/tests/test_helpers/helpers.go
@@ -21,7 +21,7 @@ const testParentDir = "/tmp/gocryptfs-test-parent"
 // GocryptfsBinary is the assumed path to the gocryptfs build.
 const GocryptfsBinary = "../../gocryptfs"
 
-// TmpDir is used by "go test" running package test s in parallel! We create a
+// TmpDir is a unique temporary directory. "go test" runs package tests in parallel. We create a
 // unique TmpDir in init() so the tests do not interfere.
 var TmpDir string
 

--- a/tests/test_helpers/helpers.go
+++ b/tests/test_helpers/helpers.go
@@ -17,16 +17,18 @@ import (
 
 // TmpDir will be created inside this directory
 const testParentDir = "/tmp/gocryptfs-test-parent"
+
+// GocryptfsBinary is the assumed path to the gocryptfs build.
 const GocryptfsBinary = "../../gocryptfs"
 
-// "go test" runs package tests in parallel! We create a unique TmpDir in
-// init() so the tests do not interfere.
+// TmpDir is used by "go test" running package test s in parallel! We create a
+// unique TmpDir in init() so the tests do not interfere.
 var TmpDir string
 
-// TmpDir + "/default-plain"
+// DefaultPlainDir is TmpDir + "/default-plain"
 var DefaultPlainDir string
 
-// TmpDir + "/default-cipher"
+// DefaultCipherDir is TmpDir + "/default-cipher"
 var DefaultCipherDir string
 
 func init() {
@@ -40,7 +42,7 @@ func init() {
 	DefaultCipherDir = TmpDir + "/default-cipher"
 }
 
-// ResetTmpDir - delete TmpDir, create new dir tree:
+// ResetTmpDir deletes TmpDir, create new dir tree:
 //
 // TmpDir
 // |-- DefaultPlainDir
@@ -167,7 +169,7 @@ func UnmountPanic(dir string) {
 	}
 }
 
-// UnmountError tries to unmount "dir" and returns the resulting error.
+// UnmountErr tries to unmount "dir" and returns the resulting error.
 func UnmountErr(dir string) error {
 	var cmd *exec.Cmd
 	if runtime.GOOS == "darwin" {
@@ -180,7 +182,7 @@ func UnmountErr(dir string) error {
 	return cmd.Run()
 }
 
-// Return md5 string for file "filename"
+// Md5fn returns an md5 string for file "filename"
 func Md5fn(filename string) string {
 	buf, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -190,14 +192,14 @@ func Md5fn(filename string) string {
 	return Md5hex(buf)
 }
 
-// Return md5 string for "buf"
+// Md5hex returns an md5 string for "buf"
 func Md5hex(buf []byte) string {
 	rawHash := md5.Sum(buf)
 	hash := hex.EncodeToString(rawHash[:])
 	return hash
 }
 
-// Verify that the file size equals "want". This checks:
+// VerifySize checks that the file size equals "want". This checks:
 // 1) Size reported by Stat()
 // 2) Number of bytes returned when reading the whole file
 func VerifySize(t *testing.T, path string, want int) {
@@ -216,7 +218,7 @@ func VerifySize(t *testing.T, path string, want int) {
 	}
 }
 
-// Create and delete a directory
+// TestMkdirRmdir creates and deletes a directory
 func TestMkdirRmdir(t *testing.T, plainDir string) {
 	dir := plainDir + "/dir1"
 	err := os.Mkdir(dir, 0777)
@@ -263,7 +265,7 @@ func TestMkdirRmdir(t *testing.T, plainDir string) {
 	}
 }
 
-// Create and rename a file
+// TestRename creates and renames a file
 func TestRename(t *testing.T, plainDir string) {
 	file1 := plainDir + "/rename1"
 	file2 := plainDir + "/rename2"
@@ -278,7 +280,7 @@ func TestRename(t *testing.T, plainDir string) {
 	syscall.Unlink(file2)
 }
 
-// verifyExistence - check in 3 ways that "path" exists:
+// VerifyExistence checks in 3 ways that "path" exists:
 // stat, open, readdir
 func VerifyExistence(path string) bool {
 	// Check that file can be stated


### PR DESCRIPTION
This fixes most of the warnings from "golint ./...", which are primarily warnings related to Go naming conventions and comment standards.

This fixes warnings from the following categories:
"don't use ALL_CAPS in Go names; use CamelCase"
"exported function XXX should have comment or be unexported"
"exported var XXX should have its own declaration"
"comment on exported function XXX should be of the form "XXX ...""
"exported func XXX returns unexported type *yyy, which can be annoying to use"
"if block ends with a return statement, so drop this else and outdent its block"

One class of golint warnings remains after this PR, which is due to package naming:
"don't use an underscore in package name"
