### PR TITLE
fusefrontend_reverse cast Stat_t.Dev to uint64

### DIFF
--- a/internal/fusefrontend_reverse/rfs.go
+++ b/internal/fusefrontend_reverse/rfs.go
@@ -135,7 +135,7 @@ func (rfs *reverseFS) inoAwareStat(relPlainPath string) (*fuse.Attr, fuse.Status
 	// The file has hard links. We have to give it a stable inode number so
 	// tar or rsync can find them.
 	if fi.Mode().IsRegular() && st.Nlink > 1 {
-		di := devIno{st.Dev, st.Ino}
+		di := devIno{uint64(st.Dev), st.Ino}
 		rfs.inoMapLock.Lock()
 		stableIno := rfs.inoMap[di]
 		if stableIno == 0 {


### PR DESCRIPTION
The [Stat_t.Dev](https://golang.org/pkg/syscall/#Stat_t) docs say `unit64`, but on [macOS amd64](https://golang.org/src/syscall/ztypes_darwin_amd64.go) it's an `int32`.
Forcing a cast to make macOS happy (see #15).