### PR TITLE
Further explain the use of 'scryptn' parameter

### DIFF
--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -200,9 +200,9 @@ Options:
 	For more details visit https://github.com/rfjakob/gocryptfs/issues/92 .
 
 **-scryptn int**
-:	scrypt cost parameter logN. Setting this to a lower value speeds up
-	mounting but makes the password susceptible to brute-force attacks
-	(default 16)
+:	scrypt cost parameter logN. Possible values: 10-62. Setting this to a lower
+        value speeds up	mounting and reduces its memory needs, but makes
+	the password susceptible to brute-force attacks	(default 16).
 
 **-speed**
 :	Run crypto speed test. Benchmark Go's built-in GCM against OpenSSL

--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -200,7 +200,7 @@ Options:
 	For more details visit https://github.com/rfjakob/gocryptfs/issues/92 .
 
 **-scryptn int**
-:	scrypt cost parameter logN. Possible values: 10-62. Setting this to a lower
+:	scrypt cost parameter logN. Possible values: 10-28. Setting this to a lower
         value speeds up	mounting and reduces its memory needs, but makes
 	the password susceptible to brute-force attacks	(default 16).
 

--- a/cli_args.go
+++ b/cli_args.go
@@ -124,8 +124,8 @@ func parseCliOpts() (args argContainer) {
 	flagSet.StringVar(&args.fsname, "fsname", "", "Override the filesystem name")
 	flagSet.IntVar(&args.notifypid, "notifypid", 0, "Send USR1 to the specified process after "+
 		"successful mount - used internally for daemonization")
-	flagSet.IntVar(&args.scryptn, "scryptn", configfile.ScryptDefaultLogN, "scrypt cost parameter logN. "+
-		"A lower value speeds up mounting but makes the password susceptible to brute-force attacks")
+	flagSet.IntVar(&args.scryptn, "scryptn", configfile.ScryptDefaultLogN, "scrypt cost parameter logN. Possible values: 10-62. "+
+		"A lower value speeds up mounting and reduces its memory needs, but makes the password susceptible to brute-force attacks")
 	// Ignored otions
 	var dummyBool bool
 	ignoreText := "(ignored for compatibility)"

--- a/cli_args.go
+++ b/cli_args.go
@@ -124,7 +124,7 @@ func parseCliOpts() (args argContainer) {
 	flagSet.StringVar(&args.fsname, "fsname", "", "Override the filesystem name")
 	flagSet.IntVar(&args.notifypid, "notifypid", 0, "Send USR1 to the specified process after "+
 		"successful mount - used internally for daemonization")
-	flagSet.IntVar(&args.scryptn, "scryptn", configfile.ScryptDefaultLogN, "scrypt cost parameter logN. Possible values: 10-62. "+
+	flagSet.IntVar(&args.scryptn, "scryptn", configfile.ScryptDefaultLogN, "scrypt cost parameter logN. Possible values: 10-28. "+
 		"A lower value speeds up mounting and reduces its memory needs, but makes the password susceptible to brute-force attacks")
 	// Ignored otions
 	var dummyBool bool


### PR DESCRIPTION
Just a small PR to further explain the use of 'scryptn' parameter by telling the possible values.

Actually, I was playing around with the parameters of gocryptfs, and I had to debug the code to understand that the command line parameter is expected to be the exponent instead of the final value.

The error I was getting was a bit confusing:

```
gocryptfs -init -scryptn 2048 ram_ciphertext/
Choose a password for protecting your files.
Password: 
Repeat: 
2017/03/25 14:30:58 DeriveKey failed: scrypt: N must be > 1 and a power of 2
panic: DeriveKey failed: scrypt: N must be > 1 and a power of 2
```
