### PR TITLE
This is working on macos

### DIFF
--- a/internal/stupidgcm/stupidgcm.go
+++ b/internal/stupidgcm/stupidgcm.go
@@ -4,6 +4,8 @@
 // decryption functions. It only support 32-byte keys and 16-bit IVs.
 package stupidgcm
 
+// #cgo LDFLAGS: -L/usr/local/opt/openssl/lib
+// #cgo CFLAGS: -I/usr/local/opt/openssl/include
 // #include <openssl/evp.h>
 // #cgo pkg-config: libcrypto
 import "C"

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	"path/filepath"
 	"runtime"
@@ -128,12 +129,34 @@ func printVersion() {
 		tlog.ProgramName, GitVersion, buildFlags, GitVersionFuse, built)
 }
 
+func loadFuseIfNeeded() {
+	if runtime.GOOS == "darwin" {
+		if _, err := os.Stat("/dev/osxfuse0"); err != nil {
+			const oldLoadOsxFuseBin = "/Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs"
+			const newLoadOsxFuseBin = "/Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse"
+			bin := oldLoadOsxFuseBin
+			if _, err := os.Stat(newLoadOsxFuseBin); err == nil {
+				bin = newLoadOsxFuseBin
+			}
+			cmd := exec.Command(bin)
+			cmd.Run()
+		}
+	}
+}
+
 func main() {
 	runtime.GOMAXPROCS(4)
 	var err error
 	// Parse all command-line options (i.e. arguments starting with "-")
 	// into "args". Path arguments are parsed below.
 	args := parseCliOpts()
+
+	// On some OSes we might need to load fuse if we are mounting a
+	// filesystem.
+	if flagSet.NArg() == 2 {
+		loadFuseIfNeeded()
+	}
+
 	// Fork a child into the background if "-fg" is not set AND we are mounting
 	// a filesystem. The child will do all the work.
 	if !args.fg && flagSet.NArg() == 2 {

--- a/mount.go
+++ b/mount.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log/syslog"
 	"net"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -263,6 +265,12 @@ func initFuseFrontend(key []byte, args *argContainer, confFile *configfile.ConfF
 	if args.reverse {
 		mOpts.Name += "-reverse"
 	}
+
+	// Add a volume name if running osxfuse
+	if runtime.GOOS == "darwin" {
+		mOpts.Options = append(mOpts.Options, fmt.Sprintf("volname=%s", path.Base(args.mountpoint)))
+	}
+
 	// The kernel enforces read-only operation, we just have to pass "ro".
 	// Reverse mounts are always read-only.
 	if args.ro || args.reverse {


### PR DESCRIPTION
This implements some of the changes discussed in #15 
The LDFLAGS and CFLAGS will work on OSX and if the paths don't exist in Linux the lines are just ignored of course.

Another addition of specifying a volname for osxfuse. If I use `gocryptfs cypher plain` then the resulting volume should be named 'plain' just as it would be on Linux.

This works in macos 10.12.3, Ubuntu 16.10, and Centos 7.3