### PR TITLE
Consistent file owners for virtual files in reverse mode

### DIFF
--- a/internal/fusefrontend_reverse/reverse_longnames.go
+++ b/internal/fusefrontend_reverse/reverse_longnames.go
@@ -96,13 +96,6 @@ func (rfs *ReverseFS) newNameFile(relPath string) (nodefs.File, fuse.Status) {
 		return nil, fuse.ToStatus(err)
 	}
 	content := []byte(rfs.nameTransform.EncryptName(e, dirIV))
-	parentFile := filepath.Join(rfs.args.Cipherdir, pDir)
-	
-	fi, err := os.Stat(filepath.Join(rfs.args.Cipherdir, pDir, e))
-	if err != nil {
-		return nil, fuse.ToStatus(err)
-	}
-	st := fi.Sys().(*syscall.Stat_t)
-
-	return rfs.newVirtualFile(content, parentFile, st.Uid, st.Gid)
+	parentFile := filepath.Join(rfs.args.Cipherdir, pDir, e)
+	return rfs.newVirtualFile(content, parentFile)
 }

--- a/internal/fusefrontend_reverse/reverse_longnames.go
+++ b/internal/fusefrontend_reverse/reverse_longnames.go
@@ -97,25 +97,12 @@ func (rfs *ReverseFS) newNameFile(relPath string) (nodefs.File, fuse.Status) {
 	}
 	content := []byte(rfs.nameTransform.EncryptName(e, dirIV))
 	parentFile := filepath.Join(rfs.args.Cipherdir, pDir)
-
-
-	//search the owner of the underlying plain file
-        absPath, err := rfs.abs(filepath.Join(pDir, e), nil)
-	if err != nil {
-		return nil, fuse.ToStatus(err)
-	}
-	var fi os.FileInfo
-	if relPath == "" {
-		// Look through symlinks for the root dir
-		fi, err = os.Stat(absPath)
-	} else {
-		fi, err = os.Lstat(absPath)
-	}
+	
+	fi, err := os.Stat(filepath.Join(rfs.args.Cipherdir, pDir, e))
 	if err != nil {
 		return nil, fuse.ToStatus(err)
 	}
 	st := fi.Sys().(*syscall.Stat_t)
-
 
 	return rfs.newVirtualFile(content, parentFile, st.Uid, st.Gid)
 }

--- a/internal/fusefrontend_reverse/reverse_longnames.go
+++ b/internal/fusefrontend_reverse/reverse_longnames.go
@@ -97,5 +97,25 @@ func (rfs *ReverseFS) newNameFile(relPath string) (nodefs.File, fuse.Status) {
 	}
 	content := []byte(rfs.nameTransform.EncryptName(e, dirIV))
 	parentFile := filepath.Join(rfs.args.Cipherdir, pDir)
-	return rfs.newVirtualFile(content, parentFile)
+
+
+	//search the owner of the underlying plain file
+        absPath, err := rfs.abs(filepath.Join(pDir, e), nil)
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	var fi os.FileInfo
+	if relPath == "" {
+		// Look through symlinks for the root dir
+		fi, err = os.Stat(absPath)
+	} else {
+		fi, err = os.Lstat(absPath)
+	}
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	st := fi.Sys().(*syscall.Stat_t)
+
+
+	return rfs.newVirtualFile(content, parentFile, st.Uid, st.Gid)
 }

--- a/internal/fusefrontend_reverse/rfs.go
+++ b/internal/fusefrontend_reverse/rfs.go
@@ -312,7 +312,7 @@ func (rfs *ReverseFS) OpenDir(cipherPath string, context *fuse.Context) ([]fuse.
 	virtualFiles := make([]fuse.DirEntry, len(entries)+1)
 	// Virtual gocryptfs.diriv file
 	virtualFiles[0] = fuse.DirEntry{
-		Mode: syscall.S_IFREG | 0400,
+		Mode: syscall.S_IFREG | 0444,
 		Name: nametransform.DirIVFilename,
 	}
 	// Actually used entries
@@ -330,7 +330,7 @@ func (rfs *ReverseFS) OpenDir(cipherPath string, context *fuse.Context) ([]fuse.
 			if len(cName) > syscall.NAME_MAX {
 				cName = rfs.nameTransform.HashLongName(cName)
 				dotNameFile := fuse.DirEntry{
-					Mode: syscall.S_IFREG | 0600,
+					Mode: syscall.S_IFREG | 0666,
 					Name: cName + nametransform.LongNameSuffix,
 				}
 				virtualFiles[nVirtual] = dotNameFile


### PR DESCRIPTION
This PR addresses the Issue #95 , about "Confusing file owner for longname files in reverse mode".

It affects only the reverse mode, and introduces three main modifications:
1. The "gocryptfs.diriv" files are assigned the owner and group of the gocryptfs process. In my opinion, these are virtual files, and they shall be owned by the user who mounted the gocryptfs folder and is therefore interested in reading it.
2. The "gocryptfs.longname.XXXX.name" files are assigned the owner and group of the underlying plaintext file. Therefore it is consistent with the file "gocryptfs.longname.XXXX" that has the encrypted contents of the plaintext file.
3. The two virtual files mentioned above are given -r--r--r-- permissions. This is consistent with the behavior described in function Access in internal/fusefrontend_reverse/rfs.go where all virtual files are always readable. Behavior also observed in point c) in #95 .

Please don't hesitate to tell me what you think and how to improve it, it is my first time writing code in Go language ;)