### PR TITLE
Add an option to force decode of encrypted files from corrupted media

### DIFF
--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -61,6 +61,16 @@ to mount the gocryptfs filesytem without user interaction.
 Stay in the foreground instead of forking away. Implies "-nosyslog".
 For compatability, "-f" is also accepted, but "-fg" is preferred.
 
+#### -force_decode
+Force decode of encrypted files even if the integrity check fails, instead of
+failing with an IO error. Warning messages are still printed to syslog if corrupted 
+files are encountered.
+It can be useful to recover files from disks with bad sectors or other corrupted
+media. It shall not be used if the origin of corruption is unknown, specially
+if you want to run executable files.
+It requires gocryptfs to be compiled with openssl support and implies -openssl true.
+It is not compatible with -aessiv.
+
 #### -fsname string
 Override the filesystem name (first column in df -T). Can also be
 passed as "-o fsname=" and is equivalent to libfuse's option of the

--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -68,8 +68,9 @@ files are encountered.
 It can be useful to recover files from disks with bad sectors or other corrupted
 media. It shall not be used if the origin of corruption is unknown, specially
 if you want to run executable files.
-It requires gocryptfs to be compiled with openssl support and implies -openssl true.
-It is not compatible with -aessiv.
+It has no effect in reverse mode. It requires gocryptfs to be compiled with openssl
+support and implies -openssl true. Because of this, it is not compatible with -aessiv,
+that uses built-in Go crpyto.
 
 #### -fsname string
 Override the filesystem name (first column in df -T). Can also be

--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -61,14 +61,15 @@ to mount the gocryptfs filesytem without user interaction.
 Stay in the foreground instead of forking away. Implies "-nosyslog".
 For compatability, "-f" is also accepted, but "-fg" is preferred.
 
-#### -force_decode
+#### -forcedecode
 Force decode of encrypted files even if the integrity check fails, instead of
 failing with an IO error. Warning messages are still printed to syslog if corrupted 
 files are encountered.
 It can be useful to recover files from disks with bad sectors or other corrupted
 media. It shall not be used if the origin of corruption is unknown, specially
-if you want to run executable files.
-It has no effect in reverse mode. It requires gocryptfs to be compiled with openssl
+if you want to run executable files. For corrupted media, note that you probably want
+to use dd_rescue(1) instead.
+This option has no effect in reverse mode. It requires gocryptfs to be compiled with openssl
 support and implies -openssl true. Because of this, it is not compatible with -aessiv,
 that uses built-in Go crpyto.
 

--- a/cli_args.go
+++ b/cli_args.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/configfile"
 	"github.com/rfjakob/gocryptfs/internal/prefer_openssl"
 	"github.com/rfjakob/gocryptfs/internal/tlog"
+	"github.com/rfjakob/gocryptfs/internal/stupidgcm"
 )
 
 // argContainer stores the parsed CLI options and arguments
@@ -18,7 +19,7 @@ type argContainer struct {
 	debug, init, zerokey, fusedebug, openssl, passwd, fg, version,
 	plaintextnames, quiet, nosyslog, wpanic,
 	longnames, allow_other, ro, reverse, aessiv, nonempty, raw64,
-	noprealloc, speed, hkdf, serialize_reads bool
+	noprealloc, speed, hkdf, serialize_reads, force_decode bool
 	masterkey, mountpoint, cipherdir, cpuprofile, extpass,
 	memprofile, ko, passfile, ctlsock, fsname string
 	// Configuration file name override
@@ -113,6 +114,8 @@ func parseCliOpts() (args argContainer) {
 	flagSet.BoolVar(&args.speed, "speed", false, "Run crypto speed test")
 	flagSet.BoolVar(&args.hkdf, "hkdf", true, "Use HKDF as an additional key derivation step")
 	flagSet.BoolVar(&args.serialize_reads, "serialize_reads", false, "Try to serialize read operations")
+	flagSet.BoolVar(&args.force_decode, "force_decode", false, "Force decode of files even if integrity check fails."+
+		" Requires gocryptfs to be compiled with openssl support and implies -openssl true")
 	flagSet.StringVar(&args.masterkey, "masterkey", "", "Mount with explicit master key")
 	flagSet.StringVar(&args.cpuprofile, "cpuprofile", "", "Write cpu profile to specified file")
 	flagSet.StringVar(&args.memprofile, "memprofile", "", "Write memory profile to specified file")
@@ -153,6 +156,22 @@ func parseCliOpts() (args argContainer) {
 			tlog.Fatal.Printf("Invalid \"-openssl\" setting: %v", err)
 			os.Exit(ErrExitUsage)
 		}
+	}
+	// "-force_decode" only works with openssl. Check compilation and command line parameters
+	if args.force_decode == true {
+		if stupidgcm.BuiltWithoutOpenssl == true {
+			tlog.Fatal.Printf("The -force_decode flag requires openssl support, but gocryptfs was compiled without it!")
+			os.Exit(ErrExitUsage)
+		}
+		if args.aessiv == true {
+			tlog.Fatal.Printf("The -force_decode and -aessiv flags are incompatible because they use different crypto libs (openssl vs native Go)")
+			os.Exit(ErrExitUsage)
+		}
+		v, e := strconv.ParseBool(opensslAuto)
+		if e == nil && v == false {
+			tlog.Warn.Printf("-openssl set to true, as it is required by -force_decode flag")
+		}
+		args.openssl = true
 	}
 	// '-passfile FILE' is a shortcut for -extpass='/bin/cat -- FILE'
 	if args.passfile != "" {

--- a/cli_args.go
+++ b/cli_args.go
@@ -167,11 +167,16 @@ func parseCliOpts() (args argContainer) {
 			tlog.Fatal.Printf("The -force_decode and -aessiv flags are incompatible because they use different crypto libs (openssl vs native Go)")
 			os.Exit(ErrExitUsage)
 		}
-		v, e := strconv.ParseBool(opensslAuto)
-		if e == nil && v == false {
-			tlog.Warn.Printf("-openssl set to true, as it is required by -force_decode flag")
+		if args.reverse == true {
+			tlog.Warn.Printf("Reverse mode chosen, the -force_decode option is ignored")
+			args.force_decode = false
+		} else {
+			v, e := strconv.ParseBool(opensslAuto)
+			if e == nil && v == false {
+				tlog.Warn.Printf("-openssl set to true, as it is required by -force_decode flag")
+			}
+			args.openssl = true
 		}
-		args.openssl = true
 	}
 	// '-passfile FILE' is a shortcut for -extpass='/bin/cat -- FILE'
 	if args.passfile != "" {

--- a/internal/configfile/config_file.go
+++ b/internal/configfile/config_file.go
@@ -225,7 +225,7 @@ func getKeyEncrypter(scryptHash []byte, useHKDF bool) *contentenc.ContentEnc {
 	if useHKDF {
 		IVLen = contentenc.DefaultIVBits
 	}
-	cc := cryptocore.New(scryptHash, cryptocore.BackendGoGCM, IVLen, useHKDF)
+	cc := cryptocore.New(scryptHash, cryptocore.BackendGoGCM, IVLen, useHKDF, false)
 	ce := contentenc.New(cc, 4096, false)
 	return ce
 }

--- a/internal/configfile/config_file.go
+++ b/internal/configfile/config_file.go
@@ -226,6 +226,6 @@ func getKeyEncrypter(scryptHash []byte, useHKDF bool) *contentenc.ContentEnc {
 		IVLen = contentenc.DefaultIVBits
 	}
 	cc := cryptocore.New(scryptHash, cryptocore.BackendGoGCM, IVLen, useHKDF)
-	ce := contentenc.New(cc, 4096)
+	ce := contentenc.New(cc, 4096, false)
 	return ce
 }

--- a/internal/contentenc/content.go
+++ b/internal/contentenc/content.go
@@ -9,6 +9,7 @@ import (
 	"log"
 
 	"github.com/rfjakob/gocryptfs/internal/cryptocore"
+	"github.com/rfjakob/gocryptfs/internal/stupidgcm"
 	"github.com/rfjakob/gocryptfs/internal/tlog"
 )
 
@@ -85,7 +86,9 @@ func (be *ContentEnc) DecryptBlocks(ciphertext []byte, firstBlockNo uint64, file
 		var pBlock []byte
 		pBlock, err = be.DecryptBlock(cBlock, firstBlockNo, fileID)
 		if err != nil {
-			break
+			if be.forceDecode == false || (be.forceDecode == true && stupidgcm.AuthError != err) {
+				break
+			}
 		}
 		pBuf.Write(pBlock)
 		firstBlockNo++
@@ -136,7 +139,9 @@ func (be *ContentEnc) DecryptBlock(ciphertext []byte, blockNo uint64, fileID []b
 	if err != nil {
 		tlog.Warn.Printf("DecryptBlock: %s, len=%d", err.Error(), len(ciphertextOrig))
 		tlog.Debug.Println(hex.Dump(ciphertextOrig))
-		if be.forceDecode == false {
+		if be.forceDecode == true {
+			return plaintext, err
+		} else {
 			return nil, err
 		}
 	}

--- a/internal/contentenc/content_test.go
+++ b/internal/contentenc/content_test.go
@@ -24,7 +24,7 @@ func TestSplitRange(t *testing.T) {
 
 	key := make([]byte, cryptocore.KeyLen)
 	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true)
-	f := New(cc, DefaultBS)
+	f := New(cc, DefaultBS, false)
 
 	for _, r := range ranges {
 		parts := f.ExplodePlainRange(r.offset, r.length)
@@ -52,7 +52,7 @@ func TestCiphertextRange(t *testing.T) {
 
 	key := make([]byte, cryptocore.KeyLen)
 	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true)
-	f := New(cc, DefaultBS)
+	f := New(cc, DefaultBS, false)
 
 	for _, r := range ranges {
 
@@ -75,7 +75,7 @@ func TestCiphertextRange(t *testing.T) {
 func TestBlockNo(t *testing.T) {
 	key := make([]byte, cryptocore.KeyLen)
 	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true)
-	f := New(cc, DefaultBS)
+	f := New(cc, DefaultBS, false)
 
 	b := f.CipherOffToBlockNo(788)
 	if b != 0 {

--- a/internal/contentenc/content_test.go
+++ b/internal/contentenc/content_test.go
@@ -23,7 +23,7 @@ func TestSplitRange(t *testing.T) {
 		testRange{6654, 8945})
 
 	key := make([]byte, cryptocore.KeyLen)
-	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true)
+	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true, false)
 	f := New(cc, DefaultBS, false)
 
 	for _, r := range ranges {
@@ -51,7 +51,7 @@ func TestCiphertextRange(t *testing.T) {
 		testRange{6654, 8945})
 
 	key := make([]byte, cryptocore.KeyLen)
-	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true)
+	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true, false)
 	f := New(cc, DefaultBS, false)
 
 	for _, r := range ranges {
@@ -74,7 +74,7 @@ func TestCiphertextRange(t *testing.T) {
 
 func TestBlockNo(t *testing.T) {
 	key := make([]byte, cryptocore.KeyLen)
-	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true)
+	cc := cryptocore.New(key, cryptocore.BackendOpenSSL, DefaultIVBits, true, false)
 	f := New(cc, DefaultBS, false)
 
 	b := f.CipherOffToBlockNo(788)

--- a/internal/cryptocore/cryptocore.go
+++ b/internal/cryptocore/cryptocore.go
@@ -51,7 +51,7 @@ type CryptoCore struct {
 // Even though the "GCMIV128" feature flag is now mandatory, we must still
 // support 96-bit IVs here because they were used for encrypting the master
 // key in gocryptfs.conf up to gocryptfs v1.2. v1.3 switched to 128 bits.
-func New(key []byte, aeadType AEADTypeEnum, IVBitLen int, useHKDF bool) *CryptoCore {
+func New(key []byte, aeadType AEADTypeEnum, IVBitLen int, useHKDF bool, forceDecode bool) *CryptoCore {
 	if len(key) != KeyLen {
 		log.Panic(fmt.Sprintf("Unsupported key length %d", len(key)))
 	}
@@ -86,7 +86,7 @@ func New(key []byte, aeadType AEADTypeEnum, IVBitLen int, useHKDF bool) *CryptoC
 			if IVLen != 16 {
 				log.Panic("stupidgcm only supports 128-bit IVs")
 			}
-			aeadCipher = stupidgcm.New(gcmKey)
+			aeadCipher = stupidgcm.New(gcmKey, forceDecode)
 		case BackendGoGCM:
 			goGcmBlockCipher, err := aes.NewCipher(gcmKey)
 			if err != nil {

--- a/internal/cryptocore/cryptocore_test.go
+++ b/internal/cryptocore/cryptocore_test.go
@@ -8,15 +8,15 @@ import (
 func TestCryptoCoreNew(t *testing.T) {
 	key := make([]byte, 32)
 	for _, useHKDF := range []bool{true, false} {
-		c := New(key, BackendOpenSSL, 128, useHKDF)
+		c := New(key, BackendOpenSSL, 128, useHKDF, false)
 		if c.IVLen != 16 {
 			t.Fail()
 		}
-		c = New(key, BackendGoGCM, 96, useHKDF)
+		c = New(key, BackendGoGCM, 96, useHKDF, false)
 		if c.IVLen != 12 {
 			t.Fail()
 		}
-		c = New(key, BackendGoGCM, 128, useHKDF)
+		c = New(key, BackendGoGCM, 128, useHKDF, false)
 		if c.IVLen != 16 {
 			t.Fail()
 		}
@@ -32,5 +32,5 @@ func TestNewPanic(t *testing.T) {
 	}()
 
 	key := make([]byte, 16)
-	New(key, BackendOpenSSL, 128, true)
+	New(key, BackendOpenSSL, 128, true, false)
 }

--- a/internal/fusefrontend/args.go
+++ b/internal/fusefrontend/args.go
@@ -31,4 +31,6 @@ type Args struct {
 	HKDF bool
 	// Try to serialize read operations, "-serialize_reads"
 	SerializeReads bool
+	// Force decode even if integrity check fails (openSSL only)
+	ForceDecode bool
 }

--- a/internal/fusefrontend/file.go
+++ b/internal/fusefrontend/file.go
@@ -197,7 +197,9 @@ func (f *file) doRead(off uint64, length uint64) ([]byte, fuse.Status) {
 	if err != nil {
 		curruptBlockNo := firstBlockNo + f.contentEnc.PlainOffToBlockNo(uint64(len(plaintext)))
 		tlog.Warn.Printf("ino%d: doRead: corrupt block #%d: %v", f.devIno.ino, curruptBlockNo, err)
-		return nil, fuse.EIO
+		if (f.fs.args.ForceDecode == false) {
+			return nil, fuse.EIO
+		}
 	}
 
 	// Crop down to the relevant part

--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -40,7 +40,7 @@ var _ pathfs.FileSystem = &FS{} // Verify that interface is implemented.
 
 // NewFS returns a new encrypted FUSE overlay filesystem.
 func NewFS(args Args) *FS {
-	cryptoCore := cryptocore.New(args.Masterkey, args.CryptoBackend, contentenc.DefaultIVBits, args.HKDF)
+	cryptoCore := cryptocore.New(args.Masterkey, args.CryptoBackend, contentenc.DefaultIVBits, args.HKDF, args.ForceDecode)
 	contentEnc := contentenc.New(cryptoCore, contentenc.DefaultBS, args.ForceDecode)
 	nameTransform := nametransform.New(cryptoCore.EMECipher, args.LongNames, args.Raw64)
 

--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -41,7 +41,7 @@ var _ pathfs.FileSystem = &FS{} // Verify that interface is implemented.
 // NewFS returns a new encrypted FUSE overlay filesystem.
 func NewFS(args Args) *FS {
 	cryptoCore := cryptocore.New(args.Masterkey, args.CryptoBackend, contentenc.DefaultIVBits, args.HKDF)
-	contentEnc := contentenc.New(cryptoCore, contentenc.DefaultBS)
+	contentEnc := contentenc.New(cryptoCore, contentenc.DefaultBS, args.ForceDecode)
 	nameTransform := nametransform.New(cryptoCore.EMECipher, args.LongNames, args.Raw64)
 
 	if args.SerializeReads {

--- a/internal/fusefrontend_reverse/rfs.go
+++ b/internal/fusefrontend_reverse/rfs.go
@@ -44,8 +44,8 @@ func NewFS(args fusefrontend.Args) *ReverseFS {
 		log.Panic("reverse mode must use AES-SIV, everything else is insecure")
 	}
 	initLongnameCache()
-	cryptoCore := cryptocore.New(args.Masterkey, args.CryptoBackend, contentenc.DefaultIVBits, args.HKDF)
-	contentEnc := contentenc.New(cryptoCore, contentenc.DefaultBS, false) //no force_decode in reverse mode
+	cryptoCore := cryptocore.New(args.Masterkey, args.CryptoBackend, contentenc.DefaultIVBits, args.HKDF, false)
+	contentEnc := contentenc.New(cryptoCore, contentenc.DefaultBS, false)
 	nameTransform := nametransform.New(cryptoCore.EMECipher, args.LongNames, args.Raw64)
 
 	return &ReverseFS{

--- a/internal/fusefrontend_reverse/rfs.go
+++ b/internal/fusefrontend_reverse/rfs.go
@@ -45,7 +45,7 @@ func NewFS(args fusefrontend.Args) *ReverseFS {
 	}
 	initLongnameCache()
 	cryptoCore := cryptocore.New(args.Masterkey, args.CryptoBackend, contentenc.DefaultIVBits, args.HKDF)
-	contentEnc := contentenc.New(cryptoCore, contentenc.DefaultBS)
+	contentEnc := contentenc.New(cryptoCore, contentenc.DefaultBS, false) //no force_decode in reverse mode
 	nameTransform := nametransform.New(cryptoCore.EMECipher, args.LongNames, args.Raw64)
 
 	return &ReverseFS{

--- a/internal/speed/speed.go
+++ b/internal/speed/speed.go
@@ -72,7 +72,7 @@ func bStupidGCM(b *testing.B) {
 	in := make([]byte, blockSize)
 	b.SetBytes(int64(len(in)))
 
-	sGCM := stupidgcm.New(key)
+	sGCM := stupidgcm.New(key, false)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/stupidgcm/stupidgcm.go
+++ b/internal/stupidgcm/stupidgcm.go
@@ -22,21 +22,26 @@ const (
 	keyLen = 32
 	ivLen  = 16
 	tagLen = 16
+
 )
 
 // stupidGCM implements the cipher.AEAD interface
 type stupidGCM struct {
-	key []byte
+	key         []byte
+	forceDecode   bool
 }
+
+//authentication error
+var AuthError error = fmt.Errorf("stupidgcm: message authentication failed")
 
 var _ cipher.AEAD = &stupidGCM{}
 
 // New returns a new cipher.AEAD implementation..
-func New(key []byte) cipher.AEAD {
+func New(key []byte, forceDecode bool) cipher.AEAD {
 	if len(key) != keyLen {
 		log.Panicf("Only %d-byte keys are supported", keyLen)
 	}
-	return stupidGCM{key: key}
+	return stupidGCM{key: key, forceDecode: forceDecode}
 }
 
 func (g stupidGCM) NonceSize() int {
@@ -188,7 +193,11 @@ func (g stupidGCM) Open(dst, iv, in, authData []byte) ([]byte, error) {
 	if res != 1 {
 		// The error code must always be checked by the calling function, because the decrypted buffer
 		// may contain corrupted data that we are returning in case the user forced reads
-		return append(dst, buf...), fmt.Errorf("stupidgcm: message authentication failed")
+		if g.forceDecode == true {
+			return append(dst, buf...), AuthError
+		} else {
+			return nil,	            AuthError
+		}
 	}
 
 	return append(dst, buf...), nil

--- a/internal/stupidgcm/stupidgcm.go
+++ b/internal/stupidgcm/stupidgcm.go
@@ -186,7 +186,9 @@ func (g stupidGCM) Open(dst, iv, in, authData []byte) ([]byte, error) {
 	C.EVP_CIPHER_CTX_free(ctx)
 
 	if res != 1 {
-		return nil, fmt.Errorf("stupidgcm: message authentication failed")
+		// The error code must always be checked by the calling function, because the decrypted buffer
+		// may contain corrupted data that we are returning in case the user forced reads
+		return append(dst, buf...), fmt.Errorf("stupidgcm: message authentication failed")
 	}
 
 	return append(dst, buf...), nil

--- a/internal/stupidgcm/stupidgcm_test.go
+++ b/internal/stupidgcm/stupidgcm_test.go
@@ -27,7 +27,7 @@ func randBytes(n int) []byte {
 // GCM implemenatation and verifies that the results are identical.
 func TestEncryptDecrypt(t *testing.T) {
 	key := randBytes(32)
-	sGCM := New(key)
+	sGCM := New(key, false)
 	authData := randBytes(24)
 	iv := randBytes(16)
 	dst := make([]byte, 71) // 71 = random length
@@ -77,7 +77,7 @@ func TestEncryptDecrypt(t *testing.T) {
 // error
 func TestCorruption(t *testing.T) {
 	key := randBytes(32)
-	sGCM := New(key)
+	sGCM := New(key, false)
 	authData := randBytes(24)
 	iv := randBytes(16)
 
@@ -94,7 +94,7 @@ func TestCorruption(t *testing.T) {
 	// Corrupt first byte
 	sOut[0]++
 	sOut2, sErr = sGCM.Open(nil, iv, sOut, authData)
-	if sErr == nil {
+	if sErr == nil || sOut2 != nil {
 		t.Fatalf("Should have gotten error")
 	}
 	sOut[0]--
@@ -102,7 +102,7 @@ func TestCorruption(t *testing.T) {
 	// Corrupt last byte
 	sOut[len(sOut)-1]++
 	sOut2, sErr = sGCM.Open(nil, iv, sOut, authData)
-	if sErr == nil {
+	if sErr == nil || sOut2 != nil {
 		t.Fatalf("Should have gotten error")
 	}
 	sOut[len(sOut)-1]--
@@ -110,7 +110,7 @@ func TestCorruption(t *testing.T) {
 	// Append one byte
 	sOut = append(sOut, 0)
 	sOut2, sErr = sGCM.Open(nil, iv, sOut, authData)
-	if sErr == nil {
+	if sErr == nil || sOut2 != nil {
 		t.Fatalf("Should have gotten error")
 	}
 }

--- a/internal/stupidgcm/stupidgcm_test.go
+++ b/internal/stupidgcm/stupidgcm_test.go
@@ -94,7 +94,7 @@ func TestCorruption(t *testing.T) {
 	// Corrupt first byte
 	sOut[0]++
 	sOut2, sErr = sGCM.Open(nil, iv, sOut, authData)
-	if sErr == nil || sOut2 != nil {
+	if sErr == nil {
 		t.Fatalf("Should have gotten error")
 	}
 	sOut[0]--
@@ -102,7 +102,7 @@ func TestCorruption(t *testing.T) {
 	// Corrupt last byte
 	sOut[len(sOut)-1]++
 	sOut2, sErr = sGCM.Open(nil, iv, sOut, authData)
-	if sErr == nil || sOut2 != nil {
+	if sErr == nil {
 		t.Fatalf("Should have gotten error")
 	}
 	sOut[len(sOut)-1]--
@@ -110,7 +110,7 @@ func TestCorruption(t *testing.T) {
 	// Append one byte
 	sOut = append(sOut, 0)
 	sOut2, sErr = sGCM.Open(nil, iv, sOut, authData)
-	if sErr == nil || sOut2 != nil {
+	if sErr == nil {
 		t.Fatalf("Should have gotten error")
 	}
 }

--- a/internal/stupidgcm/without_openssl.go
+++ b/internal/stupidgcm/without_openssl.go
@@ -14,12 +14,15 @@ const (
 	BuiltWithoutOpenssl = true
 )
 
+//authentication error - needed to compile as same varaible is exported when openssl is enable via stupidgcm.go
+var AuthError error = fmt.Errorf("stupidgcm: message authentication failed with openssl disabled!")
+
 func errExit() {
 	fmt.Fprintln(os.Stderr, "gocryptfs has been compiled without openssl support but you are still trying to use openssl")
 	os.Exit(2)
 }
 
-func New(_ []byte) stupidGCM {
+func New(_ []byte, _ bool) stupidGCM {
 	errExit()
 	// Never reached
 	return stupidGCM{}

--- a/mount.go
+++ b/mount.go
@@ -192,7 +192,7 @@ func initFuseFrontend(key []byte, args *argContainer, confFile *configfile.ConfF
 		NoPrealloc:     args.noprealloc,
 		HKDF:           args.hkdf,
 		SerializeReads: args.serialize_reads,
-		ForceDecode:    args.force_decode,
+		ForceDecode:    args.forcedecode,
 	}
 	// confFile is nil when "-zerokey" or "-masterkey" was used
 	if confFile != nil {

--- a/mount.go
+++ b/mount.go
@@ -192,6 +192,7 @@ func initFuseFrontend(key []byte, args *argContainer, confFile *configfile.ConfF
 		NoPrealloc:     args.noprealloc,
 		HKDF:           args.hkdf,
 		SerializeReads: args.serialize_reads,
+		ForceDecode:    args.force_decode,
 	}
 	// confFile is nil when "-zerokey" or "-masterkey" was used
 	if confFile != nil {


### PR DESCRIPTION
Hello,

I miss an option to force decode of encrypted files even if the integrity check fails. Maybe I was quite unlucky in the past, but the last 3 media storages I had (2 HDD + 1 SD card) failed with corrupted sectors :/ Therefore, I require a way to try to recover a part of those files.

This pull request adds an option -force_decode that allows to read corrupted data from files, and keeps printing error messages to system log. This option is disabled by default and it only works with openssl, since the built-in Go library always returns an empty buffer when integrity check fails (https://github.com/golang/go/issues/13886).

Some tests:

1. Corrupt a file by appending some extra bytes (note the extra characters at the begining of the last line, before the prompt):
```
gocryptfs -force_decode /media/gocryptfs/ciphertext/ /media/gocryptfs/plaintext
yo@wtf3-virtual:/media/gocryptfs/plaintext$ echo "This is a file stored in a disk with bad sectors" > test
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cat test 
This is a file stored in a disk with bad sectors
yo@wtf3-virtual:/media/gocryptfs/plaintext$ echo a >> ../ciphertext/zKRx4326hkD1oaSQA4qYyQ
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cat test 
This is a file stored in a disk with bad sectors
Ohyo@wtf3-virtual:/media/gocryptfs/plaintext$ 
```
In /var/log/syslog there is:
`
Apr  8 17:00:57 wtf3-virtual gocryptfs[6530]: DecryptBlock: stupidgcm: message authentication failed, len=83
`


2. Corrupt a file by flipping a bit in the middle of the file with an hex editor (note the 'a' turned into a 'q'):
```
gocryptfs -force_decode /media/gocryptfs/ciphertext/ /media/gocryptfs/plaintext
yo@wtf3-virtual:/media/gocryptfs/plaintext$ echo "This is a file stored in a disk with bad sectors" > test
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cat test 
This is a file stored in a disk with bad sectors
yo@wtf3-virtual:/media/gocryptfs/plaintext$ bless ../ciphertext/zKRx4326hkD1oaSQA4qYyQ 
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cat test 
This is q file stored in a disk with bad sectors
yo@wtf3-virtual:/media/gocryptfs/plaintext$ 

```
In /var/log/syslog there is:
`
Apr  8 17:04:20 wtf3-virtual gocryptfs[6530]: DecryptBlock: stupidgcm: message authentication failed, len=81
`

3. Corrupt a file by adding some data at the beginning. In this case, nothing can be recovered because the file header is affected by the corruption:

```
yo@wtf3-virtual:/media/gocryptfs/plaintext$ echo "This is a file stored in a disk with bad sectors" > test
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cat test 
This is a file stored in a disk with bad sectors
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cd ../ciphertext/
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ echo a > a
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ cat zKRx4326hkD1oaSQA4qYyQ >> a
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ mv a zKRx4326hkD1oaSQA4qYyQ 
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ cd ../plaintext
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cat test 
cat: test: Function not implemented
```
In /var/log/syslog there is:
`
Apr  8 17:12:32 wtf3-virtual gocryptfs[6530]: go-fuse: can't convert error type: ParseHeader: invalid version: got 24842, want 2
`


4. Corrupt a file by changing the section corresponding to the block IV. In this case, nothing can be recovered neither:
```
yo@wtf3-virtual:/media/gocryptfs/plaintext$ echo "This is a file stored in a disk with bad sectors" > test
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cat test 
This is a file stored in a disk with bad sectors
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cd ../ciphertext/
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ ll
total 20
drwxrwxrwx 2 root root 4096 avril  8 17:12 ./
drwxr-xr-x 5 root root 4096 mars  28 01:15 ../
-r-------- 1 yo   yo    408 avril  8 16:49 gocryptfs.conf
-r-------- 1 yo   yo     16 avril  8 16:49 gocryptfs.diriv
-rw-rw-r-- 1 yo   yo     99 avril  8 17:16 zKRx4326hkD1oaSQA4qYyQ
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ head -c 18 zKRx4326hkD1oaSQA4qYyQ > a
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ echo a >> a
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ tail -c 79 zKRx4326hkD1oaSQA4qYyQ >> a
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ mv a zKRx4326hkD1oaSQA4qYyQ 
yo@wtf3-virtual:/media/gocryptfs/ciphertext$ cd ../plaintext
yo@wtf3-virtual:/media/gocryptfs/plaintext$ cat test 
µ�O�� �'��@/o�p��/�
                   a6Y�=z㝜�dl�e�Ճ�.���^T�yo@wtf3-virtual:/media/gocryptfs/plaintext$ 
yo@wtf3-virtual:/media/gocryptfs/plaintext$ 
```
In /var/log/syslog there is:
`
Apr  8 17:23:24 wtf3-virtual gocryptfs[6530]: DecryptBlock: stupidgcm: message authentication failed, len=81
`

Actually, given the GCM mode of operation (XOR'ing the plaintext with an encrypted counter to get the cipertext: https://en.wikipedia.org/wiki/Galois/Counter_Mode), we can recover almost all of the file if the corrupted section doesn't affect the header or IV.