### PR TITLE
fusefrontend_reverse: Do not mix up cache information for different directories

### DIFF
--- a/internal/fusefrontend_reverse/reverse_longnames.go
+++ b/internal/fusefrontend_reverse/reverse_longnames.go
@@ -51,7 +51,7 @@ func initLongnameCache() {
 // findLongnameParent converts "gocryptfs.longname.XYZ" to the plaintext name
 func (rfs *ReverseFS) findLongnameParent(dir string, dirIV []byte, longname string) (plaintextName string, err error) {
 	longnameCacheLock.Lock()
-	hit := longnameParentCache[longname]
+	hit := longnameParentCache[dir + "/" + longname]
 	longnameCacheLock.Unlock()
 	if hit != "" {
 		return hit, nil
@@ -79,7 +79,7 @@ func (rfs *ReverseFS) findLongnameParent(dir string, dirIV []byte, longname stri
 			log.Panic("logic error or wrong shortNameMax constant?")
 		}
 		hName := rfs.nameTransform.HashLongName(cName)
-		longnameParentCache[hName] = plaintextName
+		longnameParentCache[dir + "/" + hName] = plaintextName
 		if longname == hName {
 			hit = plaintextName
 		}


### PR DESCRIPTION
Fixes https://github.com/rfjakob/gocryptfs/issues/168

I decided to use the dir instead of the dirIV because it seems a bit easier here (especially when the dirIV could be variable length).