### PR TITLE
Multiple fixes for PlaintextNames mode

### DIFF
--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -448,8 +448,7 @@ func (fs *FS) Symlink(target string, linkName string, context *fuse.Context) (co
 			return fuse.ToStatus(err)
 		}
 		// Create "gocryptfs.longfile." symlink
-		// TODO use syscall.Symlinkat once it is available in Go
-		err = syscall.Symlink(cTarget, cPath)
+		err = syscallcompat.Symlinkat(cTarget, int(dirfd.Fd()), cName)
 		if err != nil {
 			nametransform.DeleteLongName(dirfd, cName)
 		}

--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -388,7 +388,7 @@ func (fs *FS) Unlink(path string, context *fuse.Context) (code fuse.Status) {
 	}
 
 	cName := filepath.Base(cPath)
-	if nametransform.IsLongContent(cName) {
+	if !fs.args.PlaintextNames && nametransform.IsLongContent(cName) {
 		var dirfd *os.File
 		dirfd, err = os.Open(filepath.Dir(cPath))
 		if err != nil {

--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -287,9 +287,9 @@ func (fs *FS) Mknod(path string, mode uint32, dev uint32, context *fuse.Context)
 		return fuse.ToStatus(err)
 	}
 	defer dirfd.Close()
-	// Create ".name" file to store long file name
+	// Create ".name" file to store long file name (except in PlaintextNames mode)
 	cName := filepath.Base(cPath)
-	if nametransform.IsLongContent(cName) {
+	if !fs.args.PlaintextNames && nametransform.IsLongContent(cName) {
 		err = fs.nameTransform.WriteLongName(dirfd, cName, path)
 		if err != nil {
 			return fuse.ToStatus(err)

--- a/internal/fusefrontend/names.go
+++ b/internal/fusefrontend/names.go
@@ -3,6 +3,7 @@ package fusefrontend
 // This file forwards file encryption operations to cryptfs
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/rfjakob/gocryptfs/internal/configfile"
@@ -37,6 +38,20 @@ func (fs *FS) getBackingPath(relPath string) (string, error) {
 	cAbsPath := filepath.Join(fs.args.Cipherdir, cPath)
 	tlog.Debug.Printf("getBackingPath: %s + %s -> %s", fs.args.Cipherdir, relPath, cAbsPath)
 	return cAbsPath, nil
+}
+
+// openBackingPath - get the absolute encrypted path of the backing file
+// and open the corresponding directory
+func (fs *FS) openBackingPath(relPath string) (*os.File, string, error) {
+	cPath, err := fs.getBackingPath(relPath)
+	if err != nil {
+		return nil, "", err
+	}
+	dirfd, err := os.Open(filepath.Dir(cPath))
+	if err != nil {
+		return nil, "", err
+	}
+	return dirfd, filepath.Base(cPath), nil
 }
 
 // encryptPath - encrypt relative plaintext path

--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -134,12 +134,13 @@ func Dup3(oldfd int, newfd int, flags int) (err error) {
 
 // Poor man's Fchownat.
 func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
+	chdirMutex.Lock()
+	defer chdirMutex.Unlock()
 	cwd, err := syscall.Open(".", syscall.O_RDONLY, 0)
 	if err != nil {
 		return err
 	}
-	chdirMutex.Lock()
-	defer chdirMutex.Unlock()
+	defer syscall.Close(cwd)
 	err = syscall.Fchdir(dirfd)
 	if err != nil {
 		return err

--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -148,3 +148,20 @@ func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
 	defer syscall.Fchdir(cwd)
 	return syscall.Lchown(path, uid, gid)
 }
+
+// Poor man's Symlinkat.
+func Symlinkat(oldpath string, newdirfd int, newpath string) (err error) {
+	chdirMutex.Lock()
+	defer chdirMutex.Unlock()
+	cwd, err := syscall.Open(".", syscall.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(cwd)
+	err = syscall.Fchdir(newdirfd)
+	if err != nil {
+		return err
+	}
+	defer syscall.Fchdir(cwd)
+	return syscall.Symlink(oldpath, newpath)
+}

--- a/tests/matrix/matrix_test.go
+++ b/tests/matrix/matrix_test.go
@@ -789,4 +789,9 @@ func TestMkfifo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	path = test_helpers.DefaultPlainDir + "/gocryptfs.longname.XXX"
+	err = syscall.Mkfifo(path, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/tests/matrix/matrix_test.go
+++ b/tests/matrix/matrix_test.go
@@ -794,4 +794,21 @@ func TestMkfifo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = os.Remove(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Make sure the Symlink call works with paths starting with "gocryptfs.longname."
+func TestSymlink(t *testing.T) {
+	path := test_helpers.DefaultPlainDir + "/gocryptfs.longname.XXX"
+	err := syscall.Symlink("target", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Remove(path)
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This set fixes:

* Some bugs in the recently introduced `Fchownat` syscall wrapper. Unfortunately I do not have any macOS machine available, so please verify that everything still works after these changes.

* Partially issue #177 (the symlink part)

* Issue #176

* Partially issue #174 (the mknod and unlink part)

In addition the set introduces a `openBackingPath` helper to do path conversion and open a handle to the directory. This could be especially useful later for fixing issue #165.

Please let me know what you think. Also feel free to cherry-pick certain patches if you want to solve certain issues in a different way.