### PR TITLE
Use *at() syscalls for Rmdir, Chmod, Chown and Mkdir

### DIFF
--- a/init_dir.go
+++ b/init_dir.go
@@ -47,7 +47,7 @@ func initDir(args *argContainer) {
 	// Forward mode with filename encryption enabled needs a gocryptfs.diriv
 	// in the root dir
 	if !args.plaintextnames && !args.reverse {
-		err = nametransform.WriteDirIV(args.cipherdir)
+		err = nametransform.WriteDirIV(nil, args.cipherdir)
 		if err != nil {
 			tlog.Fatal.Println(err)
 			os.Exit(exitcodes.Init)

--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -388,7 +388,7 @@ func (fs *FS) Unlink(path string, context *fuse.Context) (code fuse.Status) {
 	}
 	defer dirfd.Close()
 	// Delete content
-	err = syscallcompat.Unlinkat(int(dirfd.Fd()), cName)
+	err = syscallcompat.Unlinkat(int(dirfd.Fd()), cName, 0)
 	if err != nil {
 		return fuse.ToStatus(err)
 	}

--- a/internal/nametransform/longnames.go
+++ b/internal/nametransform/longnames.go
@@ -90,7 +90,7 @@ func ReadLongName(path string) (string, error) {
 
 // DeleteLongName deletes "hashName.name".
 func DeleteLongName(dirfd *os.File, hashName string) error {
-	err := syscallcompat.Unlinkat(int(dirfd.Fd()), hashName+LongNameSuffix)
+	err := syscallcompat.Unlinkat(int(dirfd.Fd()), hashName+LongNameSuffix, 0)
 	if err != nil {
 		tlog.Warn.Printf("DeleteLongName: %v", err)
 	}

--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -187,3 +187,20 @@ func Symlinkat(oldpath string, newdirfd int, newpath string) (err error) {
 	defer syscall.Fchdir(cwd)
 	return syscall.Symlink(oldpath, newpath)
 }
+
+// Poor man's Mkdirat.
+func Mkdirat(dirfd int, path string, mode uint32) (err error) {
+	chdirMutex.Lock()
+	defer chdirMutex.Unlock()
+	cwd, err := syscall.Open(".", syscall.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(cwd)
+	err = syscall.Fchdir(dirfd)
+	if err != nil {
+		return err
+	}
+	defer syscall.Fchdir(cwd)
+	return syscall.Mkdir(path, mode)
+}

--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -137,6 +137,23 @@ func Dup3(oldfd int, newfd int, flags int) (err error) {
 	return syscall.Dup2(oldfd, newfd)
 }
 
+// Poor man's Fchmodat.
+func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+	chdirMutex.Lock()
+	defer chdirMutex.Unlock()
+	cwd, err := syscall.Open(".", syscall.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(cwd)
+	err = syscall.Fchdir(dirfd)
+	if err != nil {
+		return err
+	}
+	defer syscall.Fchdir(cwd)
+	return syscall.Chmod(path, mode)
+}
+
 // Poor man's Fchownat.
 func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
 	chdirMutex.Lock()

--- a/internal/syscallcompat/sys_linux.go
+++ b/internal/syscallcompat/sys_linux.go
@@ -109,3 +109,8 @@ func Symlinkat(oldpath string, newdirfd int, newpath string) (err error) {
 	}
 	return
 }
+
+// Mkdirat syscall.
+func Mkdirat(dirfd int, path string, mode uint32) (err error) {
+	return syscall.Mkdirat(dirfd, path, mode)
+}

--- a/internal/syscallcompat/sys_linux.go
+++ b/internal/syscallcompat/sys_linux.go
@@ -54,9 +54,19 @@ func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err e
 	return syscall.Renameat(olddirfd, oldpath, newdirfd, newpath)
 }
 
-// Unlinkat wraps the Unlinkat syscall.
-func Unlinkat(dirfd int, path string) error {
-	return syscall.Unlinkat(dirfd, path)
+// Unlinkat syscall. In old versions the 'flags' argument was missing, so
+// manually call it by using the corresponding syscall number.
+func Unlinkat(dirfd int, path string, flags int) (err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	_, _, e1 := syscall.Syscall(syscall.SYS_UNLINKAT, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(flags))
+	if e1 != 0 {
+		err = e1
+	}
+	return
 }
 
 // Mknodat wraps the Mknodat syscall.

--- a/internal/syscallcompat/sys_linux.go
+++ b/internal/syscallcompat/sys_linux.go
@@ -80,6 +80,11 @@ func Dup3(oldfd int, newfd int, flags int) (err error) {
 	return syscall.Dup3(oldfd, newfd, flags)
 }
 
+// Fchmodat syscall.
+func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
+	return syscall.Fchmodat(dirfd, path, mode, flags)
+}
+
 // Fchownat syscall.
 func Fchownat(dirfd int, path string, uid int, gid int, flags int) (err error) {
 	return syscall.Fchownat(dirfd, path, uid, gid, flags)

--- a/tests/test_helpers/helpers.go
+++ b/tests/test_helpers/helpers.go
@@ -96,7 +96,7 @@ func ResetTmpDir(createDirIV bool) {
 		panic(err)
 	}
 	if createDirIV {
-		err = nametransform.WriteDirIV(DefaultCipherDir)
+		err = nametransform.WriteDirIV(nil, DefaultCipherDir)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Patch 1 fixes an existing TODO in the code.

Patch 2 and 3 changes the implementation of Chmod and Chown, such that `openBackingPath` and *at() syscalls are used. The general idea would be that in the long term, we try to use `openBackingPath` everywhere. When we later want to harden gocryptfs against symlink race-conditions (maybe optional, since it probably will be a bit slower), it is sufficient to change only a single function, instead of adding checks everywhere in the code.

Patch 4 should fix the remaining issue from #177.
