### PR TITLE
fusefrontend_reverse: Use O_DIRECTORY in OpenDir implementation

### DIFF
--- a/internal/fusefrontend_reverse/rfs.go
+++ b/internal/fusefrontend_reverse/rfs.go
@@ -255,12 +255,12 @@ func (rfs *ReverseFS) OpenDir(cipherPath string, context *fuse.Context) ([]fuse.
 		return nil, fuse.ToStatus(err)
 	}
 	// Read plaintext dir
-	fd, err := syscallcompat.OpenNofollow(rfs.args.Cipherdir, relPath, syscall.O_RDONLY, 0)
+	fd, err := syscallcompat.OpenNofollow(rfs.args.Cipherdir, relPath, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
 	if err != nil {
 		return nil, fuse.ToStatus(err)
 	}
-	defer syscall.Close(fd)
 	entries, err := syscallcompat.Getdents(fd)
+	syscall.Close(fd)
 	if err != nil {
 		return nil, fuse.ToStatus(err)
 	}


### PR DESCRIPTION
Also get rid of the defer - it is not really necessary here.

By the way: Do we also want to use the helper function here? It is not really suitable because we want only have a directory component.