### PR TITLE
Handle PlaintextNames mode in Link

### DIFF
--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -550,7 +550,7 @@ func (fs *FS) Link(oldPath string, newPath string, context *fuse.Context) (code 
 	}
 	// Handle long file name
 	cNewName := filepath.Base(cNewPath)
-	if nametransform.IsLongContent(cNewName) {
+	if !fs.args.PlaintextNames && nametransform.IsLongContent(cNewName) {
 		dirfd, err := os.Open(filepath.Dir(cNewPath))
 		if err != nil {
 			return fuse.ToStatus(err)

--- a/internal/syscallcompat/sys_common.go
+++ b/internal/syscallcompat/sys_common.go
@@ -38,3 +38,8 @@ func Faccessat(dirfd int, path string, mode uint32) error {
 	}
 	return unix.Faccessat(dirfd, path, mode, 0)
 }
+
+// Linkat exists both in Linux and in MacOS 10.10+.
+func Linkat(olddirfd int, oldpath string, newdirfd int, newpath string, flags int) (err error) {
+	return unix.Linkat(olddirfd, oldpath, newdirfd, newpath, flags)
+}

--- a/tests/matrix/matrix_test.go
+++ b/tests/matrix/matrix_test.go
@@ -812,3 +812,26 @@ func TestSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Make sure the Link call works with paths starting with "gocryptfs.longname."
+func TestLink(t *testing.T) {
+	target := test_helpers.DefaultPlainDir + "/linktarget"
+	f, err := os.Create(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	path := test_helpers.DefaultPlainDir + "/gocryptfs.longname.XXX"
+	err = syscall.Link(target, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Remove(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Remove(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
See https://github.com/rfjakob/gocryptfs/issues/174.

The second patch changes the code to use the use the more secure `Linkat` syscall.