### PR TITLE
Pinned the link to line 38 of performance.txt to version 1.4.1 since …

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ v1.4.1, 2017-08-21
   [b2a23e9](https://github.com/rfjakob/gocryptfs/commit/b2a23e9),
   [12c0101](https://github.com/rfjakob/gocryptfs/commit/12c0101))
   * On my machine, this **doubles** the streaming read speed
-    (see [perfomance.txt](Documentation/performance.txt#L38))
+    (see [performance.txt](https://github.com/rfjakob/gocryptfs/blob/v1.4.1/Documentation/performance.txt#L38))
 * Implement and use the getdents(2) syscall for a more efficient
   OpenDir implementation
   ([e50a6a5](https://github.com/rfjakob/gocryptfs/commit/e50a6a5))


### PR DESCRIPTION
…https://github.com/rfjakob/gocryptfs/commit/f0e29d9b90b63d5fbe4164161ecb0e1035bb4af4#diff-86b7f3262ae352959ee0e04cccaac1b0 added an extra line.