### PR TITLE
added usage of reverse mode to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ See the [Quickstart](https://nuetzlich.net/gocryptfs/quickstart/) page for more 
 
 The [MANPAGE.md](Documentation/MANPAGE.md) describes all available command-line options.
 
+Use: Reverse Mode
+-----------------
+
+        $ mkdir cipher plain
+        $ ./gocryptfs -reverse -init plain
+        $ ./gocryptfs -reverse plain cipher
+
 Graphical Interface
 -------------------
 


### PR DESCRIPTION
I searched half of the internet to find a working example for how to initialize the reverse mode but failed. Even documentation that I found was incomplete - e.g.: https://wiki.archlinux.org/index.php/Gocryptfs#Example_using_reverse_mode