### PR TITLE
Globally replace 'syscall' with 'golang.org/x/sys/unix'

### DIFF
--- a/daemonize.go
+++ b/daemonize.go
@@ -1,11 +1,10 @@
 package main
-
 import (
 	"fmt"
 	"os"
 	"os/exec"
 	"os/signal"
-	"syscall"
+	"golang.org/x/sys/unix"
 
 	"github.com/rfjakob/gocryptfs/internal/exitcodes"
 	"github.com/rfjakob/gocryptfs/internal/syscallcompat"
@@ -16,7 +15,7 @@ import (
 // 0 if we get it.
 func exitOnUsr1() {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGUSR1)
+	signal.Notify(c, unix.SIGUSR1)
 	go func() {
 		<-c
 		os.Exit(0)
@@ -43,7 +42,7 @@ func forkChild() int {
 	err = c.Wait()
 	if err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
-			if waitstat, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			if waitstat, ok := exiterr.Sys().(unix.WaitStatus); ok {
 				os.Exit(waitstat.ExitStatus())
 			}
 		}

--- a/internal/contentenc/file_header.go
+++ b/internal/contentenc/file_header.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"log"
-	"syscall"
+	"golang.org/x/sys/unix"
 
 	"github.com/rfjakob/gocryptfs/internal/cryptocore"
 	"github.com/rfjakob/gocryptfs/internal/tlog"
@@ -49,18 +49,18 @@ var allZeroFileID = make([]byte, headerIDLen)
 func ParseHeader(buf []byte) (*FileHeader, error) {
 	if len(buf) != HeaderLen {
 		tlog.Warn.Printf("ParseHeader: invalid length: want %d bytes, got %d. Returning EINVAL.", HeaderLen, len(buf))
-		return nil, syscall.EINVAL
+		return nil, unix.EINVAL
 	}
 	var h FileHeader
 	h.Version = binary.BigEndian.Uint16(buf[0:headerVersionLen])
 	if h.Version != CurrentVersion {
 		tlog.Warn.Printf("ParseHeader: invalid version: want %d, got %d. Returning EINVAL.", CurrentVersion, h.Version)
-		return nil, syscall.EINVAL
+		return nil, unix.EINVAL
 	}
 	h.ID = buf[headerVersionLen:]
 	if bytes.Equal(h.ID, allZeroFileID) {
 		tlog.Warn.Printf("ParseHeader: file id is all-zero. Returning EINVAL.")
-		return nil, syscall.EINVAL
+		return nil, unix.EINVAL
 	}
 	return &h, nil
 }

--- a/internal/fusefrontend_reverse/reverse_longnames.go
+++ b/internal/fusefrontend_reverse/reverse_longnames.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -63,13 +62,13 @@ func (rfs *ReverseFS) findLongnameParent(dir string, dirIV []byte, longname stri
 	if hit != "" {
 		return hit, nil
 	}
-	fd, err := syscallcompat.OpenNofollow(rfs.args.Cipherdir, dir, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
+	fd, err := syscallcompat.OpenNofollow(rfs.args.Cipherdir, dir, unix.O_RDONLY|unix.O_DIRECTORY, 0)
 	if err != nil {
 		tlog.Warn.Printf("findLongnameParent: opendir failed: %v\n", err)
 		return "", err
 	}
 	dirEntries, err := syscallcompat.Getdents(fd)
-	syscall.Close(fd)
+	unix.Close(fd)
 	if err != nil {
 		tlog.Warn.Printf("findLongnameParent: Getdents failed: %v\n", err)
 		return "", err
@@ -93,7 +92,7 @@ func (rfs *ReverseFS) findLongnameParent(dir string, dirIV []byte, longname stri
 		}
 	}
 	if hit == "" {
-		return "", syscall.ENOENT
+		return "", unix.ENOENT
 	}
 	return hit, nil
 }

--- a/internal/nametransform/longnames.go
+++ b/internal/nametransform/longnames.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
+	"golang.org/x/sys/unix"
 
 	"github.com/rfjakob/gocryptfs/internal/syscallcompat"
 	"github.com/rfjakob/gocryptfs/internal/tlog"
@@ -112,11 +112,11 @@ func (n *NameTransform) WriteLongName(dirfd *os.File, hashName string, plainName
 
 	// Write the encrypted name into hashName.name
 	fdRaw, err := syscallcompat.Openat(int(dirfd.Fd()), hashName+LongNameSuffix,
-		syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL, 0600)
+		unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL, 0600)
 	if err != nil {
 		// Don't warn if the file already exists - this is allowed for renames
 		// and should be handled by the caller.
-		if err != syscall.EEXIST {
+		if err != unix.EEXIST {
 			tlog.Warn.Printf("WriteLongName: Openat: %v", err)
 		}
 		return err

--- a/internal/openfiletable/open_file_table.go
+++ b/internal/openfiletable/open_file_table.go
@@ -7,7 +7,7 @@ package openfiletable
 import (
 	"sync"
 	"sync/atomic"
-	"syscall"
+	"golang.org/x/sys/unix"
 )
 
 // QIno = Qualified Inode number.
@@ -20,7 +20,7 @@ type QIno struct {
 }
 
 // QInoFromStat fills a new QIno struct with the passed Stat_t info.
-func QInoFromStat(st *syscall.Stat_t) QIno {
+func QInoFromStat(st *unix.Stat_t) QIno {
 	return QIno{
 		// There are some architectures that use 32-bit values here
 		// (darwin, freebsd-32, maybe others). Add and explicit cast to make

--- a/internal/syscallcompat/emulate_test.go
+++ b/internal/syscallcompat/emulate_test.go
@@ -2,7 +2,6 @@ package syscallcompat
 
 import (
 	"os"
-	"syscall"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -22,7 +21,7 @@ func TestEmulateOpenat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer syscall.Close(rawFd)
+	defer unix.Close(rawFd)
 	if rawFd < 0 {
 		t.Fatalf("rawFd=%d", rawFd)
 	}
@@ -31,7 +30,7 @@ func TestEmulateOpenat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer syscall.Close(rawFd)
+	defer unix.Close(rawFd)
 	if rawFd < 0 {
 		t.Fatalf("rawFd=%d", rawFd)
 	}
@@ -162,8 +161,8 @@ func TestEmulateFchmodat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var st syscall.Stat_t
-	err = syscall.Lstat(tmpDir+"/chmod", &st)
+	var st unix.Stat_t
+	err = unix.Lstat(tmpDir+"/chmod", &st)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +178,7 @@ func TestEmulateFchmodat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = syscall.Lstat(tmpDir+"/chmod", &st)
+	err = unix.Lstat(tmpDir+"/chmod", &st)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +190,7 @@ func TestEmulateFchmodat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = syscall.Lstat(tmpDir+"/chmod", &st)
+	err = unix.Lstat(tmpDir+"/chmod", &st)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,8 +208,8 @@ func TestEmulateSymlinkat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var st syscall.Stat_t
-	err = syscall.Lstat(tmpDir+"/symlink1", &st)
+	var st unix.Stat_t
+	err = unix.Lstat(tmpDir+"/symlink1", &st)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +221,7 @@ func TestEmulateSymlinkat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = syscall.Lstat(tmpDir+"/symlink2", &st)
+	err = unix.Lstat(tmpDir+"/symlink2", &st)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/syscallcompat/getdents_other.go
+++ b/internal/syscallcompat/getdents_other.go
@@ -2,7 +2,6 @@ package syscallcompat
 
 import (
 	"os"
-	"syscall"
 
 	"golang.org/x/sys/unix"
 
@@ -14,7 +13,7 @@ import (
 func emulateGetdents(fd int) (out []fuse.DirEntry, err error) {
 	// os.File closes the fd in its finalizer. Duplicate the fd to not affect
 	// the original fd.
-	newFd, err := syscall.Dup(fd)
+	newFd, err := unix.Dup(fd)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +29,7 @@ func emulateGetdents(fd int) (out []fuse.DirEntry, err error) {
 	for _, name := range names {
 		var st unix.Stat_t
 		err = Fstatat(fd, name, &st, unix.AT_SYMLINK_NOFOLLOW)
-		if err == syscall.ENOENT {
+		if err == unix.ENOENT {
 			// File disappeared between readdir and stat. Pretend we did not
 			// see it.
 			continue
@@ -40,7 +39,7 @@ func emulateGetdents(fd int) (out []fuse.DirEntry, err error) {
 		}
 		newEntry := fuse.DirEntry{
 			Name: name,
-			Mode: uint32(st.Mode) & syscall.S_IFMT,
+			Mode: uint32(st.Mode) & unix.S_IFMT,
 			Ino:  st.Ino,
 		}
 		out = append(out, newEntry)

--- a/internal/syscallcompat/getdents_test.go
+++ b/internal/syscallcompat/getdents_test.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-	"syscall"
 	"testing"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 

--- a/internal/syscallcompat/open_nofollow_test.go
+++ b/internal/syscallcompat/open_nofollow_test.go
@@ -2,7 +2,7 @@ package syscallcompat
 
 import (
 	"os"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 )
 
@@ -12,11 +12,11 @@ func TestOpenNofollow(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Create a file
-	fd, err := OpenNofollow(tmpDir, "d1/d2/d3/f1", syscall.O_RDWR|syscall.O_CREAT|syscall.O_EXCL, 0600)
+	fd, err := OpenNofollow(tmpDir, "d1/d2/d3/f1", unix.O_RDWR|unix.O_CREAT|unix.O_EXCL, 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
-	syscall.Close(fd)
+	unix.Close(fd)
 	_, err = os.Stat(tmpDir + "/d1/d2/d3/f1")
 	if err != nil {
 		t.Fatal(err)
@@ -27,18 +27,18 @@ func TestOpenNofollow(t *testing.T) {
 		t.Fatal(err)
 	}
 	os.Symlink(tmpDir+"/d1.renamed", tmpDir+"/d1")
-	fd, err = OpenNofollow(tmpDir, "d1/d2/d3/f1", syscall.O_RDWR|syscall.O_CREAT, 0600)
+	fd, err = OpenNofollow(tmpDir, "d1/d2/d3/f1", unix.O_RDWR|unix.O_CREAT, 0600)
 	if err == nil {
 		t.Fatalf("should have failed")
 	}
-	if err != syscall.ELOOP && err != syscall.ENOTDIR {
+	if err != unix.ELOOP && err != unix.ENOTDIR {
 		t.Errorf("expected ELOOP or ENOTDIR, got %v", err)
 	}
 	// Check to see that the base dir can be opened as well
-	fd, err = OpenNofollow(tmpDir, "", syscall.O_RDONLY, 0)
+	fd, err = OpenNofollow(tmpDir, "", unix.O_RDONLY, 0)
 	if err != nil {
 		t.Errorf("cannot open base dir: %v", err)
 	} else {
-		syscall.Close(fd)
+		unix.Close(fd)
 	}
 }

--- a/internal/syscallcompat/sys_common.go
+++ b/internal/syscallcompat/sys_common.go
@@ -1,8 +1,6 @@
 package syscallcompat
 
 import (
-	"syscall"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -32,7 +30,7 @@ func Faccessat(dirfd int, path string, mode uint32) error {
 	if err != nil {
 		return err
 	}
-	if st.Mode&syscall.S_IFMT == syscall.S_IFLNK {
+	if st.Mode&unix.S_IFMT == unix.S_IFLNK {
 		// Pretend that a symlink is always accessible
 		return nil
 	}

--- a/internal/syscallcompat/sys_common_test.go
+++ b/internal/syscallcompat/sys_common_test.go
@@ -3,7 +3,7 @@ package syscallcompat
 import (
 	"bytes"
 	"os"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 )
 
@@ -21,7 +21,7 @@ func TestReadlinkat(t *testing.T) {
 		if target != target2 {
 			t.Errorf("target=%q != target2=%q", target, target2)
 		}
-		err = syscall.Unlink(tmpDir + "/readlinkat")
+		err = unix.Unlink(tmpDir + "/readlinkat")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/sendusr1.go
+++ b/sendusr1.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"os"
-	"syscall"
+	"golang.org/x/sys/unix"
 
 	"github.com/rfjakob/gocryptfs/internal/tlog"
 )
@@ -15,7 +15,7 @@ func sendUsr1(pid int) {
 		tlog.Warn.Printf("sendUsr1: FindProcess: %v\n", err)
 		return
 	}
-	err = p.Signal(syscall.SIGUSR1)
+	err = p.Signal(unix.SIGUSR1)
 	if err != nil {
 		tlog.Warn.Printf("sendUsr1: Signal: %v\n", err)
 	}

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 	"time"
 
@@ -142,7 +142,7 @@ func TestPasswdMasterkey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	syscall.Unlink(dir + "/gocryptfs.conf")
+	unix.Unlink(dir + "/gocryptfs.conf")
 	err = ioutil.WriteFile(dir+"/gocryptfs.conf", conf, 0600)
 	if err != nil {
 		t.Fatal(err)
@@ -331,7 +331,7 @@ func TestMountPasswordIncorrect(t *testing.T) {
 	pDir := cDir + ".mnt"
 	err := test_helpers.Mount(cDir, pDir, false, "-extpass", "echo WRONG", "-wpanic=false")
 	//          vvvvvvvvvvvvvv OMG vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-	exitCode := err.(*exec.ExitError).Sys().(syscall.WaitStatus).ExitStatus()
+	exitCode := err.(*exec.ExitError).Sys().(unix.WaitStatus).ExitStatus()
 	if exitCode != exitcodes.PasswordIncorrect {
 		t.Errorf("want=%d, got=%d", exitcodes.PasswordIncorrect, exitCode)
 	}
@@ -360,7 +360,7 @@ func TestPasswdPasswordIncorrect(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = cmd.Wait()
-	exitCode := err.(*exec.ExitError).Sys().(syscall.WaitStatus).ExitStatus()
+	exitCode := err.(*exec.ExitError).Sys().(unix.WaitStatus).ExitStatus()
 	if exitCode != exitcodes.PasswordIncorrect {
 		t.Errorf("want=%d, got=%d", exitcodes.PasswordIncorrect, exitCode)
 	}

--- a/tests/defaults/ctlsock_test.go
+++ b/tests/defaults/ctlsock_test.go
@@ -2,7 +2,7 @@ package defaults
 
 import (
 	"os"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 
 	"github.com/rfjakob/gocryptfs/internal/ctlsock"
@@ -24,7 +24,7 @@ func TestCtlSock(t *testing.T) {
 	}
 	req.EncryptPath = "not-existing-dir/xyz"
 	response = test_helpers.QueryCtlSock(t, sock, req)
-	if response.ErrNo != int32(syscall.ENOENT) || response.Result != "" {
+	if response.ErrNo != int32(unix.ENOENT) || response.Result != "" {
 		t.Errorf("incorrect error handling: %+v", response)
 	}
 	// Strange paths should not cause a crash

--- a/tests/defaults/diriv_test.go
+++ b/tests/defaults/diriv_test.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sync"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 	"time"
 
@@ -57,11 +57,11 @@ func TestDirIVRace(t *testing.T) {
 	time.Sleep(time.Millisecond)
 
 	// Overwrite dir2 with dir1
-	err = syscall.Unlink(file2)
+	err = unix.Unlink(file2)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = syscall.Rename(dir1, dir2)
+	err = unix.Rename(dir1, dir2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/example_filesystems/example_filesystems_test.go
+++ b/tests/example_filesystems/example_filesystems_test.go
@@ -10,7 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 
 	"github.com/rfjakob/gocryptfs/internal/stupidgcm"
@@ -282,14 +282,14 @@ func TestExampleFSv13reverse(t *testing.T) {
 	checkExampleFSrw(t, dirC, false)
 	// Access to encrypted version of '..' should fail
 	cPath := dirB + "/D8VwRPqWW8x7M5OEoMs0Eg"
-	err = syscall.Access(cPath, R_OK)
-	if err != syscall.ENOENT {
+	err = unix.Access(cPath, R_OK)
+	if err != unix.ENOENT {
 		t.Errorf("want ENOENT, got: %v", err)
 	}
 	// Access to encrypted version of '.' should fail
 	cPath = dirB + "/kkmARPseVj4XQFW-EL42-w"
-	err = syscall.Access(cPath, R_OK)
-	if err != syscall.ENOENT {
+	err = unix.Access(cPath, R_OK)
+	if err != unix.ENOENT {
 		t.Errorf("want ENOENT, got: %v", err)
 	}
 	// Encrypted version of dir1/dir2/file (10000 zero bytes)

--- a/tests/matrix/atime_linux.go
+++ b/tests/matrix/atime_linux.go
@@ -1,9 +1,9 @@
 package matrix
 
 import (
-	"syscall"
+	"golang.org/x/sys/unix"
 )
 
-func extractAtimeMtime(st syscall.Stat_t) [2]syscall.Timespec {
-	return [2]syscall.Timespec{st.Atim, st.Mtim}
+func extractAtimeMtime(st unix.Stat_t) [2]unix.Timespec {
+	return [2]unix.Timespec{st.Atim, st.Mtim}
 }

--- a/tests/reverse/correctness_test.go
+++ b/tests/reverse/correctness_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"syscall"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -37,7 +36,7 @@ func TestLongnameStat(t *testing.T) {
 		// which will cause "Found linked inode, but Nlink == 1" warnings and
 		// file not found errors.
 		// TODO: This problem should be handled at the go-fuse level.
-		syscall.Rename(dirA+"/"+name, test_helpers.TmpDir+"/"+fmt.Sprintf("x%d", i))
+		unix.Rename(dirA+"/"+name, test_helpers.TmpDir+"/"+fmt.Sprintf("x%d", i))
 	}
 }
 
@@ -127,15 +126,15 @@ func TestAccessVirtual(t *testing.T) {
 	var W_OK uint32 = 2
 	var X_OK uint32 = 1
 	fn := dirB + "/gocryptfs.diriv"
-	err := syscall.Access(fn, R_OK)
+	err := unix.Access(fn, R_OK)
 	if err != nil {
 		t.Errorf("%q should be readable, but got error: %v", fn, err)
 	}
-	err = syscall.Access(fn, W_OK)
+	err = unix.Access(fn, W_OK)
 	if err == nil {
 		t.Errorf("should NOT be writeable")
 	}
-	err = syscall.Access(fn, X_OK)
+	err = unix.Access(fn, X_OK)
 	if err == nil {
 		t.Errorf("should NOT be executable")
 	}
@@ -174,8 +173,8 @@ func TestAccess(t *testing.T) {
 // and not EBADMSG or EIO or anything else.
 func TestEnoent(t *testing.T) {
 	fn := dirB + "/TestEnoent"
-	_, err := syscall.Open(fn, syscall.O_RDONLY, 0)
-	if err != syscall.ENOENT {
+	_, err := unix.Open(fn, unix.O_RDONLY, 0)
+	if err != unix.ENOENT {
 		t.Errorf("want ENOENT, got: %v", err)
 	}
 }
@@ -196,8 +195,8 @@ func TestTooLongSymlink(t *testing.T) {
 		return
 	}
 	err2 := err.(*os.PathError)
-	if err2.Err != syscall.ENAMETOOLONG {
-		t.Errorf("Expected %q error, got %q instead", syscall.ENAMETOOLONG,
+	if err2.Err != unix.ENAMETOOLONG {
+		t.Errorf("Expected %q error, got %q instead", unix.ENAMETOOLONG,
 			err2.Err)
 	}
 }

--- a/tests/test_helpers/helpers.go
+++ b/tests/test_helpers/helpers.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 	"time"
 
@@ -70,7 +70,7 @@ func ResetTmpDir(createDirIV bool) {
 			err = os.Remove(d)
 			if err != nil {
 				pe := err.(*os.PathError)
-				if pe.Err == syscall.EBUSY {
+				if pe.Err == unix.EBUSY {
 					if testing.Verbose() {
 						fmt.Printf("Remove failed: %v. Maybe still mounted?\n", pe)
 					}
@@ -78,7 +78,7 @@ func ResetTmpDir(createDirIV bool) {
 					if err != nil {
 						panic(err)
 					}
-				} else if pe.Err != syscall.ENOTEMPTY {
+				} else if pe.Err != unix.ENOTEMPTY {
 					panic("Unhandled error: " + pe.Err.Error())
 				}
 				err = os.RemoveAll(d)
@@ -242,7 +242,7 @@ func TestMkdirRmdir(t *testing.T, plainDir string) {
 		t.Error(err)
 		return
 	}
-	err = syscall.Rmdir(dir)
+	err = unix.Rmdir(dir)
 	if err != nil {
 		t.Error(err)
 		return
@@ -258,16 +258,16 @@ func TestMkdirRmdir(t *testing.T, plainDir string) {
 		return
 	}
 	f.Close()
-	err = syscall.Rmdir(dir)
-	errno := err.(syscall.Errno)
-	if errno != syscall.ENOTEMPTY {
+	err = unix.Rmdir(dir)
+	errno := err.(unix.Errno)
+	if errno != unix.ENOTEMPTY {
 		t.Errorf("Should have gotten ENOTEMPTY, go %v", errno)
 	}
-	if syscall.Unlink(dir+"/file") != nil {
+	if unix.Unlink(dir+"/file") != nil {
 		t.Error(err)
 		return
 	}
-	if syscall.Rmdir(dir) != nil {
+	if unix.Rmdir(dir) != nil {
 		t.Error(err)
 		return
 	}
@@ -278,7 +278,7 @@ func TestMkdirRmdir(t *testing.T, plainDir string) {
 		t.Error(err)
 		return
 	}
-	err = syscall.Rmdir(dir)
+	err = unix.Rmdir(dir)
 	if err != nil {
 		// Make sure the directory can cleaned up by the next test run
 		os.Chmod(dir, 0700)
@@ -296,12 +296,12 @@ func TestRename(t *testing.T, plainDir string) {
 		t.Error(err)
 		return
 	}
-	err = syscall.Rename(file1, file2)
+	err = unix.Rename(file1, file2)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	syscall.Unlink(file2)
+	unix.Unlink(file2)
 }
 
 // VerifyExistence checks in 3 ways that "path" exists:
@@ -339,8 +339,8 @@ func VerifyExistence(path string) bool {
 // Du returns the disk usage of the file "fd" points to, in bytes.
 // Same as "du --block-size=1".
 func Du(t *testing.T, fd int) (nBytes int64) {
-	var st syscall.Stat_t
-	err := syscall.Fstat(fd, &st)
+	var st unix.Stat_t
+	err := unix.Fstat(fd, &st)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This might save you some time should you ever switch entirely to `golang.org/x/sys/unix`. The older `syscall` is still needed in a few places until Go-Fuse offers an API also based on `unix`.