### PR TITLE
Drop dependency on golang.org/x/syncmap

### DIFF
--- a/internal/fusefrontend_reverse/rfile.go
+++ b/internal/fusefrontend_reverse/rfile.go
@@ -5,9 +5,7 @@ import (
 	"io"
 	"os"
 	"syscall"
-
-	// In newer Go versions, this has moved to just "sync/syncmap".
-	"golang.org/x/sync/syncmap"
+	"sync"
 
 	"github.com/hanwen/go-fuse/fuse"
 	"github.com/hanwen/go-fuse/fuse/nodefs"
@@ -31,7 +29,7 @@ type reverseFile struct {
 	contentEnc *contentenc.ContentEnc
 }
 
-var inodeTable syncmap.Map
+var inodeTable sync.Map
 
 // newFile decrypts and opens the path "relPath" and returns a reverseFile
 // object. The backing file descriptor is always read-only.


### PR DESCRIPTION
For Debian, it was desirable to remove the dependency on `golang.org/x/syncmap` (now available in the standard library as `sync/map`). There is no need to merge this patch. It can be maintained indefinitely should upstream wish to remain compatible with older versions of Go.

P.S. There is another mention in `Gopkg.lock` but I do not know how to use or modify that file. Thank you!