### PR TITLE
Added option for autounmount

### DIFF
--- a/cli_args.go
+++ b/cli_args.go
@@ -33,6 +33,8 @@ type argContainer struct {
 	// Configuration file name override
 	config             string
 	notifypid, scryptn int
+	// Autounmount
+	autounmount int
 	// Helper variables that are NOT cli options all start with an underscore
 	// _configCustom is true when the user sets a custom config file name.
 	_configCustom bool
@@ -187,6 +189,9 @@ func parseCliOpts() (args argContainer) {
 		"successful mount - used internally for daemonization")
 	flagSet.IntVar(&args.scryptn, "scryptn", configfile.ScryptDefaultLogN, "scrypt cost parameter logN. Possible values: 10-28. "+
 		"A lower value speeds up mounting and reduces its memory needs, but makes the password susceptible to brute-force attacks")
+
+	flagSet.IntVar(&args.autounmount, "autounmount", 0, "Idle time in minutes before autounmount (forward mode only). 0 means stay mounted indefinitely.")
+
 	var dummyString string
 	flagSet.StringVar(&dummyString, "o", "", "For compatibility with mount(1), options can be also passed as a comma-separated list to -o on the end.")
 	// Actual parsing

--- a/internal/exitcodes/exitcodes.go
+++ b/internal/exitcodes/exitcodes.go
@@ -70,6 +70,8 @@ const (
 	TrezorError = 28
 	// ExcludeError - an error occoured while processing "-exclude"
 	ExcludeError = 29
+	// IdleTimeout means the filesystem was idle for long enough to autounmount
+	IdleTimeout = 30
 )
 
 // Err wraps an error with an associated numeric exit code

--- a/internal/fusefrontend/names.go
+++ b/internal/fusefrontend/names.go
@@ -60,9 +60,15 @@ func (fs *FS) openBackingDir(relPath string) (dirfd int, cName string, err error
 
 // encryptPath - encrypt relative plaintext path
 func (fs *FS) encryptPath(plainPath string) (string, error) {
+	if plainPath != "" {  // Empty path gets encrypted all the time without actual file accesses.
+		fs.AccessedSinceLastCheck = true
+	} else {  // Empty string gets encrypted as empty string
+		return plainPath, nil
+	}
 	if fs.args.PlaintextNames {
 		return plainPath, nil
 	}
+
 	fs.dirIVLock.RLock()
 	cPath, err := fs.nameTransform.EncryptPathDirIV(plainPath, fs.args.Cipherdir)
 	tlog.Debug.Printf("encryptPath '%s' -> '%s' (err: %v)", plainPath, cPath, err)

--- a/internal/openfiletable/open_file_table.go
+++ b/internal/openfiletable/open_file_table.go
@@ -112,3 +112,11 @@ func (c *countingMutex) Lock() {
 func WriteOpCount() uint64 {
 	return atomic.LoadUint64(&t.writeOpCount)
 }
+
+// CountOpenFiles returns how many entries are currently in the table
+// in a threadsafe manner.
+func CountOpenFiles() int {
+	t.Lock()
+	defer t.Unlock()
+	return len(t.entries)
+}


### PR DESCRIPTION
Even though filesystem notifications aren't implemented for FUSE, I decided to try my hand at implementing the autounmount feature (#128). I based it on the EncFS [autounmount code](https://github.com/vgough/encfs/blob/1974b417af189a41ffae4c6feb011d2a0498e437/encfs/main.cpp#L851), which records filesystem accesses and checks every 10 seconds whether it's idled long enough to unmount.

I've tested the feature locally, but I haven't added any tests for this flag. I also haven't worked with Go before. So please let me know if there's anything that should be done differently.

One particular concern: I worked from the assumption that the open files table is unique per-filesystem. If that's not true, I'll need to add an open file count and associated lock to the Filesystem type instead.