### PR TITLE
Support system's LDFLAGS and reproducible builds

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -57,8 +57,10 @@ if [[ -z ${BUILDDATE:-} ]] ; then
 	BUILDDATE=$(date +%Y-%m-%d)
 fi
 
-LDFLAGS="-X main.GitVersion=$GITVERSION -X main.GitVersionFuse=$GITVERSIONFUSE -X main.BuildDate=$BUILDDATE"
-go build "-ldflags=$LDFLAGS" "$@"
+GO_GCFLAGS="all=-trimpath=$PWD"
+GO_ASMFLAGS="all=-trimpath=$PWD"
+GO_LDFLAGS="-extldflags=$LDFLAGS -X main.GitVersion=$GITVERSION -X main.GitVersionFuse=$GITVERSIONFUSE -X main.BuildDate=$BUILDDATE"
+go build -ldflags "$GO_LDFLAGS" -gcflags "$GO_GCFLAGS" -asmflags "$GO_ASMFLAGS" "$@"
 
 (cd gocryptfs-xray; go build "$@")
 

--- a/build.bash
+++ b/build.bash
@@ -36,6 +36,8 @@ fi
 # go-fuse version, if available
 if [[ -d vendor/github.com/hanwen/go-fuse ]] ; then
 	GITVERSIONFUSE="[vendored]"
+	GO_GCFLAGS="all=-trimpath=$PWD"
+	GO_ASMFLAGS="all=-trimpath=$PWD"
 else
 	# go-fuse version according to git
 	# Note: git in CentOS 7 does not have "git -C" yet, so we use plain "cd".
@@ -50,15 +52,13 @@ else
 		GITVERSIONFUSE="[unknown]"
 	fi
 	cd "$MYDIR"
+	GO_GCFLAGS="all=-trimpath=$GOPATH1"
+	GO_ASMFLAGS="all=-trimpath=$GOPATH1"
 fi
 
 # Build date, something like "2017-09-06"
-if [[ -z ${BUILDDATE:-} ]] ; then
-	BUILDDATE=$(date +%Y-%m-%d)
-fi
-
-GO_GCFLAGS="all=-trimpath=$PWD"
-GO_ASMFLAGS="all=-trimpath=$PWD"
+BUILDDATE="$(date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d)"
+LDFLAGS="${LDFLAGS:-}"
 GO_LDFLAGS="-extldflags=$LDFLAGS -X main.GitVersion=$GITVERSION -X main.GitVersionFuse=$GITVERSIONFUSE -X main.BuildDate=$BUILDDATE"
 go build -ldflags "$GO_LDFLAGS" -gcflags "$GO_GCFLAGS" -asmflags "$GO_ASMFLAGS" "$@"
 


### PR DESCRIPTION
Hey there, I'm adding your tool to the official Arch Linux repos and I wanted to share a couple of security improvements.

* Supporting `$LDFLAGS` provided by the build system for example allows [enabling RELRO](https://medium.com/@HockeyInJune/relro-relocation-read-only-c8d0933faef3).
* Using `-trimpath` in `-gcflags` and `-asmflags` makes packaging [reproducible](https://reproducible-builds.org/).

Special thanks for packaging `*-src-deps.tar.gz` and signing it with PGP key 👍 

I didn't notice if you mention somewhere installation instructions for different OS, if you do, here's now the command for Arch Linux: `$ pacman -S gocryptfs`.