### PR TITLE
configfile: Explicitly wipe scrypt derived key after decrypting/encrypting master key.

### DIFF
--- a/internal/contentenc/content.go
+++ b/internal/contentenc/content.go
@@ -324,3 +324,10 @@ func (be *ContentEnc) MergeBlocks(oldData []byte, newData []byte, offset int) []
 	}
 	return out[0:outLen]
 }
+
+// Wipe tries to wipe secret keys from memory by overwriting them with zeros
+// and/or setting references to nil.
+func (be *ContentEnc) Wipe() {
+	be.cryptoCore.Wipe()
+	be.cryptoCore = nil
+}


### PR DESCRIPTION
Further raises the bar for recovering keys from memory.

The `scryptHash` array was already cleared in `EncryptKey` (added in 0efd220d1e10ac8e3d0048ff4d068cc8174e7185). However, the same logic is also required in `DecryptMasterKey`. In addition, there might be copies of the key stored in the cryptocore instance, so explicitly call `Wipe()` (using a returned callback method).