### PR TITLE
build.bash: Escape LDFLAGS before passing them to 'go build'.

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -84,7 +84,7 @@ GO_LDFLAGS="-X main.GitVersion=$GITVERSION -X main.GitVersionFuse=$GITVERSIONFUS
 
 # If LDFLAGS is set, add it as "-extldflags".
 if [[ -n ${LDFLAGS:-} ]] ; then
-	GO_LDFLAGS="-extldflags=$LDFLAGS $GO_LDFLAGS"
+	GO_LDFLAGS="$GO_LDFLAGS \"-extldflags=$LDFLAGS\""
 fi
 
 # Actual "go build" call


### PR DESCRIPTION
This ensures that ./build.bash still works when the LDFLAGS environment
variable contains multiple options, e.g., LDFLAGS="-lpthread -lm". The
correct way of passing multiple options is discussed here:
https://github.com/golang/go/issues/6234

For some unknown reason, the method only works when -extldflags is the
last argument - is this a bug in Go?

------

Note that there are also other options to pass multiple options. The following syntax also seems to work:

```-extldflags \"$LDFLAGS\"```

It also seems to be possible to pass multiple `-extldflags` arguments:

```
-       GO_LDFLAGS="-extldflags=$LDFLAGS $GO_LDFLAGS"
+       for flag in $LDFLAGS; do
+               GO_LDFLAGS="$GO_LDFLAGS -extldflags=$flag"
+       done
```
