### PR TITLE
fusefrontend: Check the correct 'err' variable.

### DIFF
--- a/internal/fusefrontend/fs_dir.go
+++ b/internal/fusefrontend/fs_dir.go
@@ -236,7 +236,7 @@ retry:
 		// meantime, undo the rename
 		err2 := syscallcompat.Renameat(parentDirFd, tmpName,
 			dirfd, nametransform.DirIVFilename)
-		if err != nil {
+		if err2 != nil {
 			tlog.Warn.Printf("Rmdir: Rename rollback failed: %v", err2)
 		}
 		return fuse.ToStatus(err)


### PR DESCRIPTION
See title.