### PR TITLE
A few more spelling fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Changelog
 v1.7-beta1, 2019-01-03
 * **Fix possible symlink race attacks in forward mode** when using allow_other + plaintextnames
   * If you use *both* `-allow_other` *and* `-plaintextnames`, you should upgrade.
-    Malicous users could trick gocryptfs into modifying files outside of `CIPHERDIR`,
+    Malicious users could trick gocryptfs into modifying files outside of `CIPHERDIR`,
 	or reading files inside `CIPHERDIR` that they should not have access to.
   * If you do not use `-plaintextnames` (disabled per default), these attacks do
     not work as symlinks are encrypted.

--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -269,7 +269,7 @@ func (fs *FS) Create(path string, flags uint32, mode uint32, context *fuse.Conte
 	return NewFile(f, fs)
 }
 
-// Chmod - FUSE call. Change permissons on "path".
+// Chmod - FUSE call. Change permissions on "path".
 //
 // Symlink-safe through use of Fchmodat().
 func (fs *FS) Chmod(path string, mode uint32, context *fuse.Context) (code fuse.Status) {

--- a/internal/nametransform/longnames.go
+++ b/internal/nametransform/longnames.go
@@ -101,7 +101,7 @@ func ReadLongNameAt(dirfd int, cName string) (string, error) {
 	return string(buf[0:n]), nil
 }
 
-// DeleteLongName deletes "hashName.name" in the directory openend at "dirfd".
+// DeleteLongName deletes "hashName.name" in the directory opened at "dirfd".
 //
 // This function is symlink-safe through the use of Unlinkat().
 func DeleteLongNameAt(dirfd int, hashName string) error {


### PR DESCRIPTION
Found with the 'codespell' utility.