### PR TITLE
fusefrontend_reverse: Fix redeclaration of 'entries' variable.

### DIFF
--- a/internal/fusefrontend_reverse/rfs.go
+++ b/internal/fusefrontend_reverse/rfs.go
@@ -330,7 +330,8 @@ func (rfs *ReverseFS) OpenDir(cipherPath string, context *fuse.Context) ([]fuse.
 		return nil, fuse.ToStatus(err)
 	}
 	if rfs.args.PlaintextNames {
-		entries, status := rfs.openDirPlaintextnames(cipherPath, entries)
+		var status fuse.Status
+		entries, status = rfs.openDirPlaintextnames(cipherPath, entries)
 		if !status.Ok() {
 			return nil, status
 		}


### PR DESCRIPTION
Go version go1.10.7 linux/amd64 complains with:

 internal/fusefrontend_reverse/rfs.go:333: declaration of "entries" shadows
 declaration at internal/fusefrontend_reverse/rfs.go:327
