### PR TITLE
fusefrontend: Allow to set/remove xattr on directory without read permission.

### DIFF
--- a/internal/fusefrontend/xattr_darwin.go
+++ b/internal/fusefrontend/xattr_darwin.go
@@ -3,6 +3,16 @@
 // Package fusefrontend interfaces directly with the go-fuse library.
 package fusefrontend
 
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/hanwen/go-fuse/fuse"
+
+	"github.com/rfjakob/gocryptfs/internal/syscallcompat"
+)
+
 func disallowedXAttrName(attr string) bool {
 	return false
 }
@@ -13,4 +23,72 @@ func filterXattrSetFlags(flags int) int {
 	const XATTR_NOSECURITY = 0x0008
 
 	return flags &^ XATTR_NOSECURITY
+}
+
+func (fs *FS) getXAttr(relPath string, cAttr string, context *fuse.Context) ([]byte, fuse.Status) {
+	// O_NONBLOCK to not block on FIFOs.
+	fd, err := fs.openBackingFile(relPath, syscall.O_RDONLY|syscall.O_NONBLOCK)
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	defer syscall.Close(fd)
+
+	cData, err := syscallcompat.Fgetxattr(fd, cAttr)
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+
+	return cData, fuse.OK
+}
+
+func (fs *FS) setXAttr(relPath string, cAttr string, cData []byte, flags int, context *fuse.Context) fuse.Status {
+	// O_NONBLOCK to not block on FIFOs.
+	fd, err := fs.openBackingFile(relPath, syscall.O_WRONLY|syscall.O_NONBLOCK)
+	// Directories cannot be opened read-write. Retry.
+	if err == syscall.EISDIR {
+		fd, err = fs.openBackingFile(relPath, syscall.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NONBLOCK)
+	}
+	if err != nil {
+		return fuse.ToStatus(err)
+	}
+	defer syscall.Close(fd)
+
+	err = unix.Fsetxattr(fd, cAttr, cData, flags)
+	return fuse.ToStatus(err)
+}
+
+func (fs *FS) removeXAttr(relPath string, cAttr string, context *fuse.Context) fuse.Status {
+	// O_NONBLOCK to not block on FIFOs.
+	fd, err := fs.openBackingFile(relPath, syscall.O_WRONLY|syscall.O_NONBLOCK)
+	// Directories cannot be opened read-write. Retry.
+	if err == syscall.EISDIR {
+		fd, err = fs.openBackingFile(relPath, syscall.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NONBLOCK)
+	}
+	if err != nil {
+		return fuse.ToStatus(err)
+	}
+	defer syscall.Close(fd)
+
+	err = unix.Fremovexattr(fd, cAttr)
+	return fuse.ToStatus(err)
+}
+
+func (fs *FS) listXAttr(relPath string, context *fuse.Context) ([]string, fuse.Status) {
+	// O_NONBLOCK to not block on FIFOs.
+	fd, err := fs.openBackingFile(relPath, syscall.O_RDONLY|syscall.O_NONBLOCK)
+	// On a symlink, openBackingFile fails with ELOOP. Let's pretend there
+	// can be no xattrs on symlinks, and always return an empty result.
+	if err == syscall.ELOOP {
+		return nil, fuse.OK
+	}
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	defer syscall.Close(fd)
+
+	cNames, err := syscallcompat.Flistxattr(fd)
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	return cNames, fuse.OK
 }

--- a/internal/fusefrontend/xattr_linux.go
+++ b/internal/fusefrontend/xattr_linux.go
@@ -4,7 +4,15 @@
 package fusefrontend
 
 import (
+	"fmt"
 	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/hanwen/go-fuse/fuse"
+
+	"github.com/rfjakob/gocryptfs/internal/syscallcompat"
 )
 
 // Only allow the "user" namespace, block "trusted" and "security", as
@@ -18,4 +26,58 @@ func disallowedXAttrName(attr string) bool {
 
 func filterXattrSetFlags(flags int) int {
 	return flags
+}
+
+func (fs *FS) getXAttr(relPath string, cAttr string, context *fuse.Context) ([]byte, fuse.Status) {
+	dirfd, cName, err := fs.openBackingDir(relPath)
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	defer syscall.Close(dirfd)
+
+	procPath := fmt.Sprintf("/proc/self/fd/%d/%s", dirfd, cName)
+	cData, err := syscallcompat.Lgetxattr(procPath, cAttr)
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	return cData, fuse.OK
+}
+
+func (fs *FS) setXAttr(relPath string, cAttr string, cData []byte, flags int, context *fuse.Context) fuse.Status {
+	dirfd, cName, err := fs.openBackingDir(relPath)
+	if err != nil {
+		return fuse.ToStatus(err)
+	}
+	defer syscall.Close(dirfd)
+
+	procPath := fmt.Sprintf("/proc/self/fd/%d/%s", dirfd, cName)
+	err = unix.Lsetxattr(procPath, cAttr, cData, flags)
+	return fuse.ToStatus(err)
+}
+
+func (fs *FS) removeXAttr(relPath string, cAttr string, context *fuse.Context) fuse.Status {
+	dirfd, cName, err := fs.openBackingDir(relPath)
+	if err != nil {
+		return fuse.ToStatus(err)
+	}
+	defer syscall.Close(dirfd)
+
+	procPath := fmt.Sprintf("/proc/self/fd/%d/%s", dirfd, cName)
+	err = unix.Lremovexattr(procPath, cAttr)
+	return fuse.ToStatus(err)
+}
+
+func (fs *FS) listXAttr(relPath string, context *fuse.Context) ([]string, fuse.Status) {
+	dirfd, cName, err := fs.openBackingDir(relPath)
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	defer syscall.Close(dirfd)
+
+	procPath := fmt.Sprintf("/proc/self/fd/%d/%s", dirfd, cName)
+	cNames, err := syscallcompat.Llistxattr(procPath)
+	if err != nil {
+		return nil, fuse.ToStatus(err)
+	}
+	return cNames, fuse.OK
 }

--- a/tests/xattr/xattr_integration_test.go
+++ b/tests/xattr/xattr_integration_test.go
@@ -129,7 +129,7 @@ func TestSetGetRmDir(t *testing.T) {
 	fn := test_helpers.DefaultPlainDir + "/TestSetGetRmDir"
 	err := syscall.Mkdir(fn, 0700)
 	if err != nil {
-		t.Fatalf("creating fifo failed: %v", err)
+		t.Fatalf("creating directory failed: %v", err)
 	}
 	setGetRmList(fn)
 }
@@ -312,6 +312,34 @@ func TestSet0200File(t *testing.T) {
 		t.Fatalf("creating empty file failed: %v", err)
 	}
 	err = xattr.LSet(fn, "user.foo", []byte("bar"))
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// Listing xattrs should work even when we don't have read access
+func TestList0000Dir(t *testing.T) {
+	fn := test_helpers.DefaultPlainDir + "/TestList0000Dir"
+	err := syscall.Mkdir(fn, 0000)
+	if err != nil {
+		t.Fatalf("creating directory failed: %v", err)
+	}
+	_, err = xattr.LList(fn)
+	os.Chmod(fn, 0700)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// Setting xattrs should work even when we don't have read access
+func TestSet0200Dir(t *testing.T) {
+	fn := test_helpers.DefaultPlainDir + "/TestSet0200Dir"
+	err := syscall.Mkdir(fn, 0200)
+	if err != nil {
+		t.Fatalf("creating directory failed: %v", err)
+	}
+	err = xattr.LSet(fn, "user.foo", []byte("bar"))
+	os.Chmod(fn, 0700)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Setting/removing extended attributes on directories was partially fixed with
commit eff35e60b63331e3e10f921792baa10b236a721d. However, on most file systems
it is also possible to do these operations without read access (see tests).

Since we cannot open a write-access fd to a directory, we have to use the
/proc/self/fd trick (already used for ListXAttr) for the other operations aswell.
For simplicity, let's separate the Linux and Darwin code again (basically revert
commit f320b76fd189a363a34bffe981aa67ab97df3362), and always use the
/proc/self/fd trick on Linux. On Darwin we use the best-effort approach with
openBackingFile() as a fallback.

More discussion about the available options is available in
https://github.com/rfjakob/gocryptfs/issues/308.