### PR TITLE
main: Run 'ensure fds' code early during the program startup.

### DIFF
--- a/cli_args.go
+++ b/cli_args.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	// Should be initialized before anything else.
+	_ "github.com/rfjakob/gocryptfs/internal/ensurestdfds"
+
 	"flag"
 	"fmt"
 	"net"

--- a/internal/ensurestdfds/init.go
+++ b/internal/ensurestdfds/init.go
@@ -1,0 +1,27 @@
+package ensurestdfds
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/rfjakob/gocryptfs/internal/exitcodes"
+)
+
+// init() ensures that file descriptors 0,1,2 are open. The Go stdlib,
+// as well as the gocryptfs code, relies on the fact that fds 0,1,2 are always
+// open.
+// See https://github.com/rfjakob/gocryptfs/issues/320 for details.
+func init() {
+	fd, err := syscall.Open("/dev/null", syscall.O_RDWR, 0)
+	if err != nil {
+		os.Exit(exitcodes.DevNull)
+	}
+	for fd <= 2 {
+		fd, err = syscall.Dup(fd)
+		if err != nil {
+			os.Exit(exitcodes.DevNull)
+		}
+	}
+	// Close excess fd (usually fd 3)
+	syscall.Close(fd)
+}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/hanwen/go-fuse/fuse"
 
@@ -150,7 +149,6 @@ func printVersion() {
 }
 
 func main() {
-	ensureStdFds()
 	mxp := runtime.GOMAXPROCS(0)
 	if mxp < 4 {
 		// On a 2-core machine, setting maxprocs to 4 gives 10% better performance
@@ -329,27 +327,4 @@ func main() {
 		fsck(&args)
 		os.Exit(0)
 	}
-}
-
-// ensureStdFds ensures that file descriptors 0,1,2 are open. The Go stdlib,
-// as well as the gocryptfs code, relies on the fact that fds 0,1,2 are always
-// open.
-// See https://github.com/rfjakob/gocryptfs/issues/320 for details.
-//
-// This function should be called as the first thing from main().
-func ensureStdFds() {
-	fd, err := syscall.Open("/dev/null", syscall.O_RDWR, 0)
-	if err != nil {
-		tlog.Fatal.Printf("ensureStdFds: open /dev/null failed: %v", err)
-		os.Exit(exitcodes.DevNull)
-	}
-	for fd <= 2 {
-		fd, err = syscall.Dup(fd)
-		if err != nil {
-			tlog.Fatal.Printf("ensureStdFds: dup failed: %v", err)
-			os.Exit(exitcodes.DevNull)
-		}
-	}
-	// Close excess fd (usually fd 3)
-	syscall.Close(fd)
 }


### PR DESCRIPTION
The files are apparently processed in alphabetic order, so cli_args.go is
processed before main.go. In order to run before the go-fuse imports, put
the 'ensure fds' code in a separate package. Debug messages are omitted
to avoid additional imports (that might contain other code messing up our
file descriptors).

---

Before merging, please verify that this also works for you.