### PR TITLE
More fixes for -allow_other

### DIFF
--- a/internal/fusefrontend/fs_dir.go
+++ b/internal/fusefrontend/fs_dir.go
@@ -5,7 +5,6 @@ package fusefrontend
 import (
 	"fmt"
 	"io"
-	"path/filepath"
 	"runtime"
 	"syscall"
 
@@ -124,15 +123,10 @@ func (fs *FS) Mkdir(newPath string, mode uint32, context *fuse.Context) (code fu
 		err = syscallcompat.Fchownat(dirfd, cName, int(context.Owner.Uid),
 			int(context.Owner.Gid), unix.AT_SYMLINK_NOFOLLOW)
 		if err != nil {
-			tlog.Warn.Printf("Mkdir %q: Fchownat(1) %d:%d failed: %v", cName, context.Owner.Uid, context.Owner.Gid, err)
+			tlog.Warn.Printf("Mkdir %q: Fchownat %d:%d failed: %v", cName, context.Owner.Uid, context.Owner.Gid, err)
 			// In case of a failure, we don't want to proceed setting more
 			// permissive modes.
 			return fuse.ToStatus(err)
-		}
-		err = syscallcompat.Fchownat(dirfd, filepath.Join(cName, nametransform.DirIVFilename),
-			int(context.Owner.Uid), int(context.Owner.Gid), unix.AT_SYMLINK_NOFOLLOW)
-		if err != nil {
-			tlog.Warn.Printf("Mkdir %q: Fchownat(2) %d:%d failed: %v", cName, context.Owner.Uid, context.Owner.Gid, err)
 		}
 	}
 	// Set mode

--- a/internal/nametransform/longnames.go
+++ b/internal/nametransform/longnames.go
@@ -129,7 +129,7 @@ func (n *NameTransform) WriteLongNameAt(dirfd int, hashName string, plainName st
 
 	// Write the encrypted name into hashName.name
 	fdRaw, err := syscallcompat.Openat(dirfd, hashName+LongNameSuffix,
-		syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL, 0600)
+		syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL, 0400)
 	if err != nil {
 		// Don't warn if the file already exists - this is allowed for renames
 		// and should be handled by the caller.


### PR DESCRIPTION
Fixes the remaining issues of https://github.com/rfjakob/gocryptfs/issues/327.

Please consider these as draft patches (and adapt them if necessary) - some of the changes (e.g., removing `Chown` for `gocryptfs.iv` files) might have side effects I am not aware of.