### PR TITLE
Switch to Setreuid/Setregid method instead of manually changing ownership of files.

### DIFF
--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -192,7 +192,7 @@ func (fs *FS) openWriteOnlyFile(dirfd int, cName string, newFlags int) (*File, f
 		return nil, fuse.ToStatus(err)
 	}
 	// The cast to uint32 fixes a build failure on Darwin, where st.Mode is uint16.
-	perms := uint32(st.Mode & 0777)
+	perms := uint32(st.Mode)
 	// Verify that we don't have read permissions
 	if perms&0400 != 0 {
 		tlog.Warn.Printf("openWriteOnlyFile: unexpected permissions %#o, returning EPERM", perms)

--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -238,15 +238,11 @@ func (fs *FS) Create(path string, flags uint32, mode uint32, context *fuse.Conte
 		return nil, fuse.ToStatus(err)
 	}
 	defer syscall.Close(dirfd)
-	// Don't set full mode before we have set the correct owner. Files with SUID/SGID
-	// mode belonging to the wrong owner would be a security risk. Even for other
-	// modes, we don't want anyone else to open the file in the meantime: the fd would
-	// stay open and could later be used to read the file.
-	origMode := mode
-	if fs.args.PreserveOwner {
-		mode = 0000
-	}
 	fd := -1
+	// Make sure context is nil if we don't want to preserve the owner
+	if !fs.args.PreserveOwner {
+		context = nil
+	}
 	// Handle long file name
 	if !fs.args.PlaintextNames && nametransform.IsLongContent(cName) {
 		// Create ".name"
@@ -255,14 +251,14 @@ func (fs *FS) Create(path string, flags uint32, mode uint32, context *fuse.Conte
 			return nil, fuse.ToStatus(err)
 		}
 		// Create content
-		fd, err = syscallcompat.Openat(dirfd, cName, newFlags|os.O_CREATE|os.O_EXCL, mode)
+		fd, err = syscallcompat.OpenatUser(dirfd, cName, newFlags|os.O_CREATE|os.O_EXCL, mode, context)
 		if err != nil {
 			nametransform.DeleteLongNameAt(dirfd, cName)
 			return nil, fuse.ToStatus(err)
 		}
 	} else {
 		// Create content, normal (short) file name
-		fd, err = syscallcompat.Openat(dirfd, cName, newFlags|syscall.O_CREAT|syscall.O_EXCL, mode)
+		fd, err = syscallcompat.OpenatUser(dirfd, cName, newFlags|syscall.O_CREAT|syscall.O_EXCL, mode, context)
 		if err != nil {
 			// xfstests generic/488 triggers this
 			if err == syscall.EMFILE {
@@ -271,24 +267,6 @@ func (fs *FS) Create(path string, flags uint32, mode uint32, context *fuse.Conte
 				tlog.Warn.Printf("Create %q: too many open files. Current \"ulimit -n\": %d", cName, lim.Cur)
 			}
 			return nil, fuse.ToStatus(err)
-		}
-	}
-	// Set owner
-	if fs.args.PreserveOwner {
-		err = syscall.Fchown(fd, int(context.Owner.Uid), int(context.Owner.Gid))
-		if err != nil {
-			tlog.Warn.Printf("Create %q: Fchown %d:%d failed: %v", cName, context.Owner.Uid, context.Owner.Gid, err)
-			// In case of a failure, we don't want to proceed setting more
-			// permissive modes.
-			syscall.Close(fd)
-			return nil, fuse.ToStatus(err)
-		}
-	}
-	// Set mode
-	if mode != origMode {
-		err = syscall.Fchmod(fd, origMode)
-		if err != nil {
-			tlog.Warn.Printf("Create %q: Fchmod %#o -> %#o failed: %v", cName, mode, origMode, err)
 		}
 	}
 	f := os.NewFile(uintptr(fd), cName)

--- a/internal/fusefrontend/fs_dir.go
+++ b/internal/fusefrontend/fs_dir.go
@@ -163,7 +163,7 @@ func (fs *FS) Rmdir(relPath string, context *fuse.Context) (code fuse.Status) {
 			return fuse.ToStatus(err)
 		}
 		// This cast is needed on Darwin, where st.Mode is uint16.
-		origMode := uint32(st.Mode & 0777)
+		origMode := uint32(st.Mode)
 		err = syscallcompat.Fchmodat(parentDirFd, cName, origMode|0700, unix.AT_SYMLINK_NOFOLLOW)
 		if err != nil {
 			tlog.Debug.Printf("Rmdir: Fchmodat failed: %v", err)

--- a/internal/fusefrontend/fs_dir.go
+++ b/internal/fusefrontend/fs_dir.go
@@ -5,7 +5,6 @@ package fusefrontend
 import (
 	"fmt"
 	"io"
-	"path/filepath"
 	"runtime"
 	"syscall"
 
@@ -124,15 +123,10 @@ func (fs *FS) Mkdir(newPath string, mode uint32, context *fuse.Context) (code fu
 		err = syscallcompat.Fchownat(dirfd, cName, int(context.Owner.Uid),
 			int(context.Owner.Gid), unix.AT_SYMLINK_NOFOLLOW)
 		if err != nil {
-			tlog.Warn.Printf("Mkdir %q: Fchownat(1) %d:%d failed: %v", cName, context.Owner.Uid, context.Owner.Gid, err)
+			tlog.Warn.Printf("Mkdir %q: Fchownat %d:%d failed: %v", cName, context.Owner.Uid, context.Owner.Gid, err)
 			// In case of a failure, we don't want to proceed setting more
 			// permissive modes.
 			return fuse.ToStatus(err)
-		}
-		err = syscallcompat.Fchownat(dirfd, filepath.Join(cName, nametransform.DirIVFilename),
-			int(context.Owner.Uid), int(context.Owner.Gid), unix.AT_SYMLINK_NOFOLLOW)
-		if err != nil {
-			tlog.Warn.Printf("Mkdir %q: Fchownat(2) %d:%d failed: %v", cName, context.Owner.Uid, context.Owner.Gid, err)
 		}
 	}
 	// Set mode

--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -63,6 +63,11 @@ func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
 	return emulateMknodat(dirfd, path, mode, dev)
 }
 
+func MknodatUser(dirfd int, path string, mode uint32, dev int, context *fuse.Context) (err error) {
+	// FIXME: take into account context.Owner
+	return Mknodat(dirfd, path, mode, dev)
+}
+
 func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
 	return emulateFchmodat(dirfd, path, mode, flags)
 }

--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -46,6 +46,11 @@ func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error) 
 	return emulateOpenat(dirfd, path, flags, mode)
 }
 
+func OpenatUser(dirfd int, path string, flags int, mode uint32, context *fuse.Context) (fd int, err error) {
+	// FIXME: take into account context.Owner
+	return Openat(dirfd, path, flags, mode)
+}
+
 func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err error) {
 	return emulateRenameat(olddirfd, oldpath, newdirfd, newpath)
 }

--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -80,6 +80,11 @@ func Symlinkat(oldpath string, newdirfd int, newpath string) (err error) {
 	return emulateSymlinkat(oldpath, newdirfd, newpath)
 }
 
+func SymlinkatUser(oldpath string, newdirfd int, newpath string, context *fuse.Context) (err error) {
+	// FIXME: take into account context.Owner
+	return Symlinkat(oldpath, newdirfd, newpath)
+}
+
 func Mkdirat(dirfd int, path string, mode uint32) (err error) {
 	return emulateMkdirat(dirfd, path, mode)
 }

--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -79,6 +79,11 @@ func Mkdirat(dirfd int, path string, mode uint32) (err error) {
 	return emulateMkdirat(dirfd, path, mode)
 }
 
+func MkdiratUser(dirfd int, path string, mode uint32, context *fuse.Context) (err error) {
+	// FIXME: take into account context.Owner
+	return Mkdirat(dirfd, path, mode)
+}
+
 func Fstatat(dirfd int, path string, stat *unix.Stat_t, flags int) (err error) {
 	return emulateFstatat(dirfd, path, stat, flags)
 }

--- a/internal/syscallcompat/sys_linux.go
+++ b/internal/syscallcompat/sys_linux.go
@@ -180,6 +180,28 @@ func Mkdirat(dirfd int, path string, mode uint32) (err error) {
 	return syscall.Mkdirat(dirfd, path, mode)
 }
 
+// MkdiratUser runs the Mkdirat syscall in the context of a different user.
+func MkdiratUser(dirfd int, path string, mode uint32, context *fuse.Context) (err error) {
+	if context != nil {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		err = syscall.Setregid(-1, int(context.Owner.Gid))
+		if err != nil {
+			return err
+		}
+		defer syscall.Setregid(-1, 0)
+
+		err = syscall.Setreuid(-1, int(context.Owner.Uid))
+		if err != nil {
+			return err
+		}
+		defer syscall.Setreuid(-1, 0)
+	}
+
+	return Mkdirat(dirfd, path, mode)
+}
+
 // Fstatat syscall.
 func Fstatat(dirfd int, path string, stat *unix.Stat_t, flags int) (err error) {
 	// Why would we ever want to call this without AT_SYMLINK_NOFOLLOW?


### PR DESCRIPTION
Draft patch for the `Sereuid`/`Setregid` method on Linux. On Darwin, for now, just ignore the ownership problem at all. This will have to be adressed before `-allow_other` is usable again.

See https://github.com/rfjakob/gocryptfs/issues/339
