### PR TITLE
fusefrontend: Do not pass unsupported flags to Faccessat on macOS.

### DIFF
--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -668,7 +668,7 @@ func (fs *FS) Access(relPath string, mode uint32, context *fuse.Context) (code f
 	if err != nil {
 		return fuse.ToStatus(err)
 	}
-	err = unix.Faccessat(dirfd, cName, mode, unix.AT_SYMLINK_NOFOLLOW)
+	err = syscallcompat.Faccessat(dirfd, cName, mode)
 	syscall.Close(dirfd)
 	return fuse.ToStatus(err)
 }


### PR DESCRIPTION
Fixes mounting of forward mounts on macOS High Sierra.

(Feel free to adjust the patch if you prefer a different version, e.g., filtering it in a syscall wrapper.)