### PR TITLE
syscallcompat: Use the same *User() syscall wrappers on both Linux and macOS.

### DIFF
--- a/internal/syscallcompat/sys_darwin.go
+++ b/internal/syscallcompat/sys_darwin.go
@@ -46,14 +46,6 @@ func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error) 
 	return emulateOpenat(dirfd, path, flags, mode)
 }
 
-func OpenatUser(dirfd int, path string, flags int, mode uint32, context *fuse.Context) (fd int, err error) {
-	// FIXME: take into account context.Owner
-	// Until we have that, filter SUID and SGID bits:
-	mode = filterSuidSgid(mode)
-
-	return Openat(dirfd, path, flags, mode)
-}
-
 func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err error) {
 	return emulateRenameat(olddirfd, oldpath, newdirfd, newpath)
 }
@@ -64,14 +56,6 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
 
 func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
 	return emulateMknodat(dirfd, path, mode, dev)
-}
-
-func MknodatUser(dirfd int, path string, mode uint32, dev int, context *fuse.Context) (err error) {
-	// FIXME: take into account context.Owner
-	// Until we have that, filter SUID and SGID bits:
-	mode = filterSuidSgid(mode)
-
-	return Mknodat(dirfd, path, mode, dev)
 }
 
 func Fchmodat(dirfd int, path string, mode uint32, flags int) (err error) {
@@ -86,21 +70,8 @@ func Symlinkat(oldpath string, newdirfd int, newpath string) (err error) {
 	return emulateSymlinkat(oldpath, newdirfd, newpath)
 }
 
-func SymlinkatUser(oldpath string, newdirfd int, newpath string, context *fuse.Context) (err error) {
-	// FIXME: take into account context.Owner
-	return Symlinkat(oldpath, newdirfd, newpath)
-}
-
 func Mkdirat(dirfd int, path string, mode uint32) (err error) {
 	return emulateMkdirat(dirfd, path, mode)
-}
-
-func MkdiratUser(dirfd int, path string, mode uint32, context *fuse.Context) (err error) {
-	// FIXME: take into account context.Owner
-	// Until we have that, filter SUID and SGID bits:
-	mode = filterSuidSgid(mode)
-
-	return Mkdirat(dirfd, path, mode)
 }
 
 func Fstatat(dirfd int, path string, stat *unix.Stat_t, flags int) (err error) {
@@ -109,9 +80,4 @@ func Fstatat(dirfd int, path string, stat *unix.Stat_t, flags int) (err error) {
 
 func Getdents(fd int) ([]fuse.DirEntry, error) {
 	return emulateGetdents(fd)
-}
-
-// filterSuidSgid removes SUID and SGID bits from "mode".
-func filterSuidSgid(mode uint32) uint32 {
-	return mode & ^uint32(syscall.S_ISGID|syscall.S_ISUID)
 }

--- a/internal/syscallcompat/sys_linux.go
+++ b/internal/syscallcompat/sys_linux.go
@@ -3,7 +3,6 @@ package syscallcompat
 
 import (
 	"fmt"
-	"runtime"
 	"sync"
 	"syscall"
 
@@ -76,28 +75,6 @@ func Openat(dirfd int, path string, flags int, mode uint32) (fd int, err error) 
 	return syscall.Openat(dirfd, path, flags, mode)
 }
 
-// OpenatUser runs the Openat syscall in the context of a different user.
-func OpenatUser(dirfd int, path string, flags int, mode uint32, context *fuse.Context) (fd int, err error) {
-	if context != nil {
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-
-		err = syscall.Setregid(-1, int(context.Owner.Gid))
-		if err != nil {
-			return -1, err
-		}
-		defer syscall.Setregid(-1, 0)
-
-		err = syscall.Setreuid(-1, int(context.Owner.Uid))
-		if err != nil {
-			return -1, err
-		}
-		defer syscall.Setreuid(-1, 0)
-	}
-
-	return Openat(dirfd, path, flags, mode)
-}
-
 // Renameat wraps the Renameat syscall.
 func Renameat(olddirfd int, oldpath string, newdirfd int, newpath string) (err error) {
 	return syscall.Renameat(olddirfd, oldpath, newdirfd, newpath)
@@ -111,28 +88,6 @@ func Unlinkat(dirfd int, path string, flags int) (err error) {
 // Mknodat wraps the Mknodat syscall.
 func Mknodat(dirfd int, path string, mode uint32, dev int) (err error) {
 	return syscall.Mknodat(dirfd, path, mode, dev)
-}
-
-// MknodatUser runs the Mknodat syscall in the context of a different user.
-func MknodatUser(dirfd int, path string, mode uint32, dev int, context *fuse.Context) (err error) {
-	if context != nil {
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-
-		err = syscall.Setregid(-1, int(context.Owner.Gid))
-		if err != nil {
-			return err
-		}
-		defer syscall.Setregid(-1, 0)
-
-		err = syscall.Setreuid(-1, int(context.Owner.Uid))
-		if err != nil {
-			return err
-		}
-		defer syscall.Setreuid(-1, 0)
-	}
-
-	return Mknodat(dirfd, path, mode, dev)
 }
 
 // Dup3 wraps the Dup3 syscall. We want to use Dup3 rather than Dup2 because Dup2
@@ -197,53 +152,9 @@ func Symlinkat(oldpath string, newdirfd int, newpath string) (err error) {
 	return unix.Symlinkat(oldpath, newdirfd, newpath)
 }
 
-// SymlinkatUser runs the Symlinkat syscall in the context of a different user.
-func SymlinkatUser(oldpath string, newdirfd int, newpath string, context *fuse.Context) (err error) {
-	if context != nil {
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-
-		err = syscall.Setregid(-1, int(context.Owner.Gid))
-		if err != nil {
-			return err
-		}
-		defer syscall.Setregid(-1, 0)
-
-		err = syscall.Setreuid(-1, int(context.Owner.Uid))
-		if err != nil {
-			return err
-		}
-		defer syscall.Setreuid(-1, 0)
-	}
-
-	return Symlinkat(oldpath, newdirfd, newpath)
-}
-
 // Mkdirat syscall.
 func Mkdirat(dirfd int, path string, mode uint32) (err error) {
 	return syscall.Mkdirat(dirfd, path, mode)
-}
-
-// MkdiratUser runs the Mkdirat syscall in the context of a different user.
-func MkdiratUser(dirfd int, path string, mode uint32, context *fuse.Context) (err error) {
-	if context != nil {
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-
-		err = syscall.Setregid(-1, int(context.Owner.Gid))
-		if err != nil {
-			return err
-		}
-		defer syscall.Setregid(-1, 0)
-
-		err = syscall.Setreuid(-1, int(context.Owner.Uid))
-		if err != nil {
-			return err
-		}
-		defer syscall.Setreuid(-1, 0)
-	}
-
-	return Mkdirat(dirfd, path, mode)
 }
 
 // Fstatat syscall.


### PR DESCRIPTION
I'm surprised a bit that exactly the same method we use on Linux also works on macOS.

Should we move it to a separate file?