### PR TITLE
Rework the Utimens handling on macOS.

### DIFF
--- a/internal/fusefrontend/file.go
+++ b/internal/fusefrontend/file.go
@@ -81,8 +81,7 @@ func NewFile(fd *os.File, fs *FS) (*File, fuse.Status) {
 	}, fuse.OK
 }
 
-// intFd - return the backing file descriptor as an integer. Used for debug
-// messages.
+// intFd - return the backing file descriptor as an integer.
 func (f *File) intFd() int {
 	return int(f.fd.Fd())
 }
@@ -120,7 +119,7 @@ func (f *File) createHeader() (fileID []byte, err error) {
 	buf := h.Pack()
 	// Prevent partially written (=corrupt) header by preallocating the space beforehand
 	if !f.fs.args.NoPrealloc {
-		err = syscallcompat.EnospcPrealloc(int(f.fd.Fd()), 0, contentenc.HeaderLen)
+		err = syscallcompat.EnospcPrealloc(f.intFd(), 0, contentenc.HeaderLen)
 		if err != nil {
 			if !syscallcompat.IsENOSPC(err) {
 				tlog.Warn.Printf("ino%d: createHeader: prealloc failed: %s\n", f.qIno.Ino, err.Error())
@@ -319,7 +318,7 @@ func (f *File) doWrite(data []byte, off int64) (uint32, fuse.Status) {
 	var err error
 	cOff := int64(blocks[0].BlockCipherOff())
 	if !f.fs.args.NoPrealloc {
-		err = syscallcompat.EnospcPrealloc(int(f.fd.Fd()), cOff, int64(len(ciphertext)))
+		err = syscallcompat.EnospcPrealloc(f.intFd(), cOff, int64(len(ciphertext)))
 		if err != nil {
 			if !syscallcompat.IsENOSPC(err) {
 				tlog.Warn.Printf("ino%d fh%d: doWrite: prealloc failed: %v", f.qIno.Ino, f.intFd(), err)
@@ -327,7 +326,7 @@ func (f *File) doWrite(data []byte, off int64) (uint32, fuse.Status) {
 			if fileWasEmpty {
 				// Kill the file header again
 				f.fileTableEntry.ID = nil
-				err2 := syscall.Ftruncate(int(f.fd.Fd()), 0)
+				err2 := syscall.Ftruncate(f.intFd(), 0)
 				if err2 != nil {
 					tlog.Warn.Printf("ino%d fh%d: doWrite: rollback failed: %v", f.qIno.Ino, f.intFd(), err2)
 				}
@@ -414,7 +413,7 @@ func (f *File) Flush() fuse.Status {
 	// Since Flush() may be called for each dup'd fd, we don't
 	// want to really close the file, we just want to flush. This
 	// is achieved by closing a dup'd fd.
-	newFd, err := syscall.Dup(int(f.fd.Fd()))
+	newFd, err := syscall.Dup(f.intFd())
 
 	if err != nil {
 		return fuse.ToStatus(err)
@@ -428,7 +427,7 @@ func (f *File) Fsync(flags int) (code fuse.Status) {
 	f.fdLock.RLock()
 	defer f.fdLock.RUnlock()
 
-	return fuse.ToStatus(syscall.Fsync(int(f.fd.Fd())))
+	return fuse.ToStatus(syscall.Fsync(f.intFd()))
 }
 
 // Chmod FUSE call
@@ -457,7 +456,7 @@ func (f *File) GetAttr(a *fuse.Attr) fuse.Status {
 
 	tlog.Debug.Printf("file.GetAttr()")
 	st := syscall.Stat_t{}
-	err := syscall.Fstat(int(f.fd.Fd()), &st)
+	err := syscall.Fstat(f.intFd(), &st)
 	if err != nil {
 		return fuse.ToStatus(err)
 	}

--- a/internal/fusefrontend/fs.go
+++ b/internal/fusefrontend/fs.go
@@ -372,10 +372,7 @@ func (fs *FS) Utimens(path string, a *time.Time, m *time.Time, context *fuse.Con
 		return fuse.ToStatus(err)
 	}
 	defer syscall.Close(dirfd)
-	ts := make([]unix.Timespec, 2)
-	ts[0] = unix.Timespec(fuse.UtimeToTimespec(a))
-	ts[1] = unix.Timespec(fuse.UtimeToTimespec(m))
-	err = unix.UtimesNanoAt(dirfd, cName, ts, unix.AT_SYMLINK_NOFOLLOW)
+	err = syscallcompat.UtimesNanoAtNofollow(dirfd, cName, a, m)
 	return fuse.ToStatus(err)
 }
 

--- a/internal/syscallcompat/sys_linux.go
+++ b/internal/syscallcompat/sys_linux.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -189,6 +190,26 @@ func MkdiratUser(dirfd int, path string, mode uint32, context *fuse.Context) (er
 	}
 
 	return Mkdirat(dirfd, path, mode)
+}
+
+func timesToTimespec(a *time.Time, m *time.Time) []unix.Timespec {
+	ts := make([]unix.Timespec, 2)
+	ts[0] = unix.Timespec(fuse.UtimeToTimespec(a))
+	ts[1] = unix.Timespec(fuse.UtimeToTimespec(m))
+	return ts
+}
+
+// FutimesNano syscall.
+func FutimesNano(fd int, a *time.Time, m *time.Time) (err error) {
+	ts := timesToTimespec(a, m)
+	procPath := fmt.Sprintf("/proc/self/fd/%d", fd)
+	return unix.UtimesNanoAt(unix.AT_FDCWD, procPath, ts, 0)
+}
+
+// UtimesNanoAtNofollow is like UtimesNanoAt but never follows symlinks.
+func UtimesNanoAtNofollow(dirfd int, path string, a *time.Time, m *time.Time) (err error) {
+	ts := timesToTimespec(a, m)
+	return unix.UtimesNanoAt(dirfd, path, ts, unix.AT_SYMLINK_NOFOLLOW)
 }
 
 // Getdents syscall.


### PR DESCRIPTION
For Linux, everything effectively stays the same. For both path-based and
fd-based Utimens() calls, we use unix.UtimesNanoAt(). To avoid introducing
a separate syscall wrapper for futimens() (as done in go-fuse, for example),
we instead use the /proc/self/fd - trick.

On macOS, this changes quite a lot:

* Path-based Utimens() calls were previously completely broken, since
  unix.UtimensNanoAt() ignores the passed file descriptor. Note that this
  cannot be fixed easily since there IS no appropriate syscall available on
  macOS prior to High Sierra (10.13). We emulate this case by using
  Fchdir() + setattrlist().

* Fd-based Utimens() calls were previously translated to f.GetAttr() (to
  fill any empty parameters) and syscall.Futimes(), which does not does
  support nanosecond precision. Both issues can be fixed by switching to
  fsetattrlist().

Fixes https://github.com/rfjakob/gocryptfs/issues/350

---------------

The first commit is cleanup and could also be omitted, if there are any objections. The second commit should be considered a draft patch, however, it fixes all the `utimens` related errors on macOS.
