### PR TITLE
Add missing -ldflags for gocryptfs-xray

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -90,7 +90,7 @@ fi
 # Actual "go build" call
 go build "-ldflags=$GO_LDFLAGS" "-gcflags=$TRIM" "-asmflags=$TRIM" "$@"
 
-(cd gocryptfs-xray; go build "-gcflags=$TRIM" "-asmflags=$TRIM" "$@")
+(cd gocryptfs-xray; go build "-ldflags=$GO_LDFLAGS" "-gcflags=$TRIM" "-asmflags=$TRIM" "$@")
 
 ./gocryptfs -version
 


### PR DESCRIPTION
Follow-up to #280 😉 

FYI, since `1.7` I included `gocryptfs-xray` to the Arch Linux distribution 👍 