### PR TITLE
Add install goal in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .phony: build
 build:
 	./build.bash
+	./Documentation/MANPAGE-render.bash
 
 .phony: test
 test:
@@ -9,3 +10,10 @@ test:
 .phony: format
 format:
 	go fmt ./...
+
+.phony: install
+install:
+	install -Dm755 -t "$(DESTDIR)/usr/bin/" gocryptfs
+	install -Dm755 -t "$(DESTDIR)/usr/bin/" gocryptfs-xray/gocryptfs-xray
+	install -Dm644 -t "$(DESTDIR)/usr/share/man/man1/" Documentation/gocryptfs.1
+	install -Dm644 -t "$(DESTDIR)/usr/share/licenses/gocryptfs" LICENSE


### PR DESCRIPTION
I noticed you had created a Makefile! Nice nice 🙂 👍 

I'm proposing to extend Makefile with the following change. This will be a declaration of what a full distribution of gocryptfs must look like (two binaries, man page and license), and which build commands to run in order to prepare all the necessary files for installation (binaries and man page).

For example packaging for Arch Linux (and I assume all other distributions) will become as simple as running "make build" followed by "make install".