### PR TITLE
Add CodeLingo Tenet to fix missing close file

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,0 +1,4 @@
+tenets:
+- import: codelingo/effective-go
+- import: codelingo/code-review-comments
+- import: codelingo/rfjakob-gocryptfs

--- a/tests/fsck/fsck_test.go
+++ b/tests/fsck/fsck_test.go
@@ -85,6 +85,7 @@ func TestExampleFses(t *testing.T) {
 			t.Errorf("fsck returned code %d but fs should be clean", code)
 		}
 	}
+	dirfd.Close()
 }
 
 // TestTerabyteFile verifies that fsck does something intelligent when it hits


### PR DESCRIPTION
Add a CodeLingo Tenet to protect the code from future instances of missing Close(), fixed in [this PR #162](https://github.com/rfjakob/gocryptfs/pull/162). Use the Tenet to find and fix several remaining cases of the issue.
