### PR TITLE
Add missing defer close file

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,4 +1,3 @@
 tenets:
 - import: codelingo/effective-go
 - import: codelingo/code-review-comments
-- import: codelingo/rfjakob-gocryptfs

--- a/daemonize.go
+++ b/daemonize.go
@@ -98,9 +98,9 @@ func redirectStdFds() {
 		tlog.Warn.Printf("redirectStdFds: could not open /dev/null: %v\n", err)
 		return
 	}
+	defer nullFd.Close()
 	err = syscallcompat.Dup3(int(nullFd.Fd()), 0, 0)
 	if err != nil {
 		tlog.Warn.Printf("redirectStdFds: stdin dup error: %v\n", err)
 	}
-	nullFd.Close()
 }

--- a/internal/configfile/config_file.go
+++ b/internal/configfile/config_file.go
@@ -274,6 +274,7 @@ func (cf *ConfFile) WriteFile() error {
 	if err != nil {
 		return err
 	}
+	defer fd.Close()
 	js, err := json.MarshalIndent(cf, "", "\t")
 	if err != nil {
 		return err
@@ -291,10 +292,6 @@ func (cf *ConfFile) WriteFile() error {
 		tlog.Warn.Printf("Warning: fsync failed: %v", err)
 		// Try sync instead
 		syscall.Sync()
-	}
-	err = fd.Close()
-	if err != nil {
-		return err
 	}
 	err = os.Rename(tmp, cf.filename)
 	return err

--- a/internal/syscallcompat/sys_common_test.go
+++ b/internal/syscallcompat/sys_common_test.go
@@ -164,7 +164,7 @@ func TestFchmodatNofollow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	defer f.Close()
 	symlink := "TestFchmodat_Symlink"
 	err = syscall.Symlink(regular, tmpDir+"/"+symlink)
 	if err != nil {

--- a/tests/defaults/performance_test.go
+++ b/tests/defaults/performance_test.go
@@ -53,6 +53,7 @@ func BenchmarkStreamRead(t *testing.B) {
 			fmt.Println(err)
 			t.FailNow()
 		}
+		defer f2.Close()
 		for h := 0; h < t.N-mb; h++ {
 			_, err = f2.Write(buf)
 			if err != nil {
@@ -60,13 +61,13 @@ func BenchmarkStreamRead(t *testing.B) {
 				t.FailNow()
 			}
 		}
-		f2.Close()
 	}
 
 	file, err := os.Open(fn)
 	if err != nil {
 		t.FailNow()
 	}
+	defer file.Close()
 	t.ResetTimer()
 	var i int
 	for i = 0; i < t.N; i++ {
@@ -79,7 +80,6 @@ func BenchmarkStreamRead(t *testing.B) {
 			t.FailNow()
 		}
 	}
-	file.Close()
 }
 
 // createFiles - create "count" files of size "size" bytes each

--- a/tests/fsck/fsck_test.go
+++ b/tests/fsck/fsck_test.go
@@ -53,6 +53,7 @@ func TestExampleFses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer dirfd.Close()
 	var fsNames []string
 	entries, err := dirfd.Readdir(0)
 	if err != nil {
@@ -85,7 +86,6 @@ func TestExampleFses(t *testing.T) {
 			t.Errorf("fsck returned code %d but fs should be clean", code)
 		}
 	}
-	dirfd.Close()
 }
 
 // TestTerabyteFile verifies that fsck does something intelligent when it hits

--- a/tests/matrix/concurrency_test.go
+++ b/tests/matrix/concurrency_test.go
@@ -36,6 +36,7 @@ func TestConcurrentReadWrite(t *testing.T) {
 			if err != nil {
 				log.Fatal(err)
 			}
+			defer fRd.Close()
 			for j := 0; j < loops; j++ {
 				n, err := fRd.ReadAt(buf, 0)
 				if err != nil && err != io.EOF {
@@ -45,7 +46,6 @@ func TestConcurrentReadWrite(t *testing.T) {
 					log.Fatalf("strange read length: %d", n)
 				}
 			}
-			fRd.Close()
 			wg.Done()
 		}()
 
@@ -56,6 +56,7 @@ func TestConcurrentReadWrite(t *testing.T) {
 			if err != nil {
 				log.Fatal(err)
 			}
+			defer fWr.Close()
 			for j := 0; j < loops; j++ {
 				err = fWr.Truncate(0)
 				if err != nil {
@@ -66,7 +67,6 @@ func TestConcurrentReadWrite(t *testing.T) {
 					log.Fatal(err)
 				}
 			}
-			fWr.Close()
 			wg.Done()
 		}()
 	}

--- a/tests/matrix/matrix_test.go
+++ b/tests/matrix/matrix_test.go
@@ -168,16 +168,13 @@ func TestWrite10Tight(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer file.Close()
 		n, err := file.Read(buf)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if n != 10 {
 			t.Fatalf("want 10 bytes, got %d", n)
-		}
-		err = file.Close()
-		if err != nil {
-			t.Fatal(err)
 		}
 		err = os.Remove(path)
 		if err != nil {
@@ -422,11 +419,11 @@ func TestNameLengths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
 	entries, err := f.Readdirnames(0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
 	cnt1 := len(entries)
 
 	wd := test_helpers.DefaultPlainDir + "/"
@@ -442,6 +439,7 @@ func TestNameLengths(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer f.Close()
 		// In v1.7-rc2, we had a bug that allowed creation of too-long names.
 		// This threw errors in like this in READDIR:
 		//
@@ -452,7 +450,6 @@ func TestNameLengths(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		f.Close()
 		cnt2 := len(entries)
 		if cnt2 != cnt1+1 {
 			t.Fatalf("len=%d: expected %d dir entries, have %d: %v", len(name), cnt1+1, cnt2, entries)

--- a/tests/reverse/correctness_test.go
+++ b/tests/reverse/correctness_test.go
@@ -242,5 +242,5 @@ func Test0100Dir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fd.Close()
+	defer fd.Close()
 }

--- a/tests/reverse/longname_perf_test.go
+++ b/tests/reverse/longname_perf_test.go
@@ -29,12 +29,12 @@ func BenchmarkLongnameStat(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	defer dirFd.Close()
 	encryptedNames, err := dirFd.Readdirnames(-1)
 	if err != nil {
 		b.Fatal(err)
 	}
 	l := len(encryptedNames)
-	dirFd.Close()
 	// Benchmark
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/tests/symlink_race/main.go
+++ b/tests/symlink_race/main.go
@@ -69,6 +69,8 @@ func openLoop() {
 			fmt.Printf("Open() failed: %v\n", err)
 			continue
 		}
+		defer f.Close()
+
 		_, err = f.Write(owned)
 		if err != nil {
 			fmt.Printf("Write() failed: %v\n", err)

--- a/tests/test_helpers/helpers.go
+++ b/tests/test_helpers/helpers.go
@@ -289,7 +289,7 @@ func VerifyExistence(path string) bool {
 	if err != nil {
 		open = false
 	}
-	fd.Close()
+	defer fd.Close()
 	// Check if file shows up in directory listing
 	readdir := false
 	dir := filepath.Dir(path)


### PR DESCRIPTION
This PR fixes missing defer close files [as specified in Effective Go](https://golang.org/doc/effective_go.html#defer). These issues were found by [this tenet](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/effective-go/defer-close-file/codelingo.yaml). Your [codelingo.yaml file](https://github.com/leilaes/gocryptfs/blob/master/codelingo.yaml) has been updated as this tenet is part of our effective-go bundle now :) 
Please note that the following cases were also found by the tenet, but have not been changed in this PR as the files have been opened in a loop:
https://github.com/leilaes/gocryptfs/blob/master/tests/matrix/concurrency_test.go#L107
https://github.com/leilaes/gocryptfs/blob/master/tests/defaults/diriv_test.go#L48
