### PR TITLE
Prevent local user ID from appearing in source tarballs

### DIFF
--- a/package-source.bash
+++ b/package-source.bash
@@ -8,7 +8,7 @@ git_archive_extra() {
 	# Add files tracked in git
 	git archive --prefix "$PREFIX/" -o $PREFIX.tar HEAD
 	# Add "extra" files
-	tar --transform "s!^!$PREFIX/!" --append -f $PREFIX.tar "$@"
+	tar --owner=root --group=root --transform "s!^!$PREFIX/!" --append -f $PREFIX.tar "$@"
 	# Compress
 	gzip -f $PREFIX.tar
 }


### PR DESCRIPTION
The local user ID (1026 jakob) appears in the source tarballs gocryptfs_v1.7_src.tar.gz and gocryptfs_v1.7_src-deps.tar.gz as the owner of VERSION, Documentation, and vendor. This issue is already fixed for the binary releases by commit 07f57314afb260d6b14227b932d66345c55ffab3, and the solution here is the same: use "tar --owner=root --group=root".