### PR TITLE
Make one timer rather than a timer each iteration.

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -2,4 +2,4 @@ tenets:
 - import: codelingo/effective-go
 - import: codelingo/code-review-comments
 - import: codelingo/rfjakob-gocryptfs
-- import: codelingo/go/ticker-in-for-switch
+- import: codelingo/go/ticker-in-for-select

--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -2,3 +2,4 @@ tenets:
 - import: codelingo/effective-go
 - import: codelingo/code-review-comments
 - import: codelingo/rfjakob-gocryptfs
+- import: codelingo/go/ticker-in-for-switch

--- a/internal/serialize_reads/sr.go
+++ b/internal/serialize_reads/sr.go
@@ -107,9 +107,7 @@ func (sr *serializerState) eventLoop() {
 	empty := true
 	timerDuration := time.Microsecond * 500
 	timer := time.NewTimer(timerDuration)
-	defer timer.Stop()
 	for {
-		timer.Reset(timerDuration)
 		if empty {
 			// If the queue is empty we block on the channel to conserve CPU
 			sb := <-sr.input
@@ -118,6 +116,7 @@ func (sr *serializerState) eventLoop() {
 		}
 		select {
 		case sb := <-sr.input:
+			timer.Stop()
 			full := sr.push(sb)
 			if full {
 				// Queue is full, unblock the new request immediately
@@ -129,6 +128,7 @@ func (sr *serializerState) eventLoop() {
 			// Looks like we have waited out all concurrent requests.
 			empty = sr.unblockOne()
 		}
+		timer.Reset(timerDuration)
 	}
 }
 

--- a/internal/serialize_reads/sr.go
+++ b/internal/serialize_reads/sr.go
@@ -105,7 +105,11 @@ func (sr *serializerState) pop() *submission {
 func (sr *serializerState) eventLoop() {
 	sr.input = make(chan *submission)
 	empty := true
+	timerDuration := time.Microsecond * 500
+	timer := time.NewTimer(timerDuration)
+	defer timer.Stop()
 	for {
+		timer.Reset(timerDuration)
 		if empty {
 			// If the queue is empty we block on the channel to conserve CPU
 			sb := <-sr.input
@@ -121,7 +125,7 @@ func (sr *serializerState) eventLoop() {
 				sr.unblockOne()
 			}
 			continue
-		case <-time.After(time.Microsecond * 500):
+		case <-timer.C:
 			// Looks like we have waited out all concurrent requests.
 			empty = sr.unblockOne()
 		}

--- a/internal/serialize_reads/sr.go
+++ b/internal/serialize_reads/sr.go
@@ -123,7 +123,6 @@ func (sr *serializerState) eventLoop() {
 				tlog.Warn.Printf("serialize_reads: queue full, forcing unblock")
 				sr.unblockOne()
 			}
-			continue
 		case <-timer.C:
 			// Looks like we have waited out all concurrent requests.
 			empty = sr.unblockOne()

--- a/mount.go
+++ b/mount.go
@@ -100,9 +100,12 @@ func doMount(args *argContainer) {
 	// Preallocation on Btrfs is broken ( https://github.com/rfjakob/gocryptfs/issues/395 )
 	// and slow ( https://github.com/rfjakob/gocryptfs/issues/63 ).
 	if !args.noprealloc {
+		// darwin does not have unix.BTRFS_SUPER_MAGIC, so we define it here
+		const BTRFS_SUPER_MAGIC = 0x9123683e
 		var st unix.Statfs_t
 		err = unix.Statfs(args.cipherdir, &st)
-		if err == nil && st.Type == unix.BTRFS_SUPER_MAGIC {
+		// Cast to uint32 avoids compile error on arm: "constant 2435016766 overflows int32"
+		if err == nil && uint32(st.Type) == BTRFS_SUPER_MAGIC {
 			tlog.Info.Printf(tlog.ColorYellow +
 				"Btrfs detected, forcing -noprealloc. See https://github.com/rfjakob/gocryptfs/issues/395 for why." +
 				tlog.ColorReset)


### PR DESCRIPTION
Rather than creating a new timer for each iteration, one timer should be defined and reset after each iteration. When using time.After() it's valuable to know that ["The underlying Timer is not recovered by the garbage collector until the timer fires. If efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer is no longer needed."](https://golang.org/src/time/sleep.go?s=4332:4733#L143)

This issue was found using the CodeLingo Tenet [ticker-in-for-select](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/go/ticker-in-for-select/codelingo.yaml) which I have added to the codelingo.yaml at the root of the repo.