### PR TITLE
Provide a manpage for statfs tool.

### DIFF
--- a/Documentation/MANPAGE-STATFS.md
+++ b/Documentation/MANPAGE-STATFS.md
@@ -1,0 +1,30 @@
+% STATFS(1)
+% github.com/rfjakob
+% Sep 2019
+
+NAME
+====
+
+statfs - dump the statfs information for PATH to console in JSON format
+
+SYNOPSIS
+========
+
+#### Examine encrypted file/directory
+statfs PATH
+
+DESCRIPTION
+===========
+
+There are no options to this command.
+
+EXAMPLES
+========
+
+Examine a directory entry:
+
+	statfs myfs/mCXnISiv7nEmyc0glGuhTQ
+
+SEE ALSO
+========
+gocryptfs(1) gocryptfs-xray(1)

--- a/Documentation/MANPAGE-render.bash
+++ b/Documentation/MANPAGE-render.bash
@@ -15,4 +15,4 @@ function render {
 
 render MANPAGE.md gocryptfs.1
 render MANPAGE-XRAY.md gocryptfs-xray.1
-
+render MANPAGE-STATFS.md statfs.1


### PR DESCRIPTION
From Debian. The `render` command in `MANPAGE-render.bash` is untested. We generate the man pages directly with `pandoc`.