### PR TITLE
Logging corrections...

### DIFF
--- a/daemonize.go
+++ b/daemonize.go
@@ -62,7 +62,11 @@ func forkChild() int {
 }
 
 // redirectStdFds redirects stderr and stdout to syslog; stdin to /dev/null
-func redirectStdFds() {
+//
+// (We're passing in a tagname (basically the mountpoint...) to be clearer
+//  than a PID which will not be the same from boot to boot and making it
+//  be consistent with the normal logging... )
+func redirectStdFds(tagName string) {
 	// Create a pipe pair "pw" -> "pr" and start logger reading from "pr".
 	// We do it ourselves instead of using StdinPipe() because we need access
 	// to the fd numbers.
@@ -71,7 +75,7 @@ func redirectStdFds() {
 		tlog.Warn.Printf("redirectStdFds: could not create pipe: %v\n", err)
 		return
 	}
-	tag := fmt.Sprintf("gocryptfs-%d-logger", os.Getpid())
+	tag := fmt.Sprintf("gocryptfs[%s]", tagName)
 	cmd := exec.Command("logger", "-t", tag)
 	cmd.Stdin = pr
 	err = cmd.Start()

--- a/internal/tlog/log.go
+++ b/internal/tlog/log.go
@@ -136,11 +136,15 @@ func init() {
 }
 
 // SwitchToSyslog redirects the output of this logger to syslog.
-func (l *toggledLogger) SwitchToSyslog(p syslog.Priority) {
-	w, err := syslog.New(p, ProgramName)
+func (l *toggledLogger) SwitchToSyslog(p syslog.Priority, tagName string) {
+	// Use Dial instead of New.  New presumes a fork of what is generated from
+	// the Dial call to clone a new connection instance of the Dial-ed in syslog.
+	w, err := syslog.Dial("", "", p, ProgramName+"["+tagName+"]")
 	if err != nil {
 		Warn.Printf("SwitchToSyslog: %v", err)
 	} else {
+		// Disable printing the timestamp, syslog already provides that
+		log.SetFlags(0)
 		l.Logger.SetOutput(w)
 		// Disable colors
 		l.prefix = ""
@@ -150,8 +154,10 @@ func (l *toggledLogger) SwitchToSyslog(p syslog.Priority) {
 
 // SwitchLoggerToSyslog redirects the default log.Logger that the go-fuse lib uses
 // to syslog.
-func SwitchLoggerToSyslog(p syslog.Priority) {
-	w, err := syslog.New(p, ProgramName)
+func SwitchLoggerToSyslog(p syslog.Priority, tagName string) {
+	// Use Dial instead of New.  New presumes a fork of what is generated from
+	// the Dial call to clone a new connection instance of the Dial-ed in syslog.
+	w, err := syslog.Dial("", "", p, ProgramName+"["+tagName+"]")
 	if err != nil {
 		Warn.Printf("SwitchLoggerToSyslog: %v", err)
 	} else {

--- a/mount.go
+++ b/mount.go
@@ -130,13 +130,15 @@ func doMount(args *argContainer) {
 		// Switch to syslog
 		if !args.nosyslog {
 			// Switch all of our logs and the generic logger to syslog
-			tlog.Info.SwitchToSyslog(syslog.LOG_USER | syslog.LOG_INFO)
-			tlog.Debug.SwitchToSyslog(syslog.LOG_USER | syslog.LOG_DEBUG)
-			tlog.Warn.SwitchToSyslog(syslog.LOG_USER | syslog.LOG_WARNING)
-			tlog.Fatal.SwitchToSyslog(syslog.LOG_USER | syslog.LOG_CRIT)
-			tlog.SwitchLoggerToSyslog(syslog.LOG_USER | syslog.LOG_WARNING)
-			// Daemons should redirect stdin, stdout and stderr
-			redirectStdFds()
+			tlog.Info.SwitchToSyslog(syslog.LOG_USER|syslog.LOG_INFO, args.mountpoint)
+			tlog.Debug.SwitchToSyslog(syslog.LOG_USER|syslog.LOG_DEBUG, args.mountpoint)
+			tlog.Warn.SwitchToSyslog(syslog.LOG_USER|syslog.LOG_WARNING, args.mountpoint)
+			tlog.Fatal.SwitchToSyslog(syslog.LOG_USER|syslog.LOG_CRIT, args.mountpoint)
+			tlog.SwitchLoggerToSyslog(syslog.LOG_USER|syslog.LOG_WARNING, args.mountpoint)
+			// Daemons should redirect stdin, stdout and stderr to /dev/null to work properly.
+			redirectStdFds(args.mountpoint)
+			// Report logging having moved to syslog TO syslog
+			tlog.Info.Println("gocryptfs starting.  Logging to syslog.")
 		}
 		// Disconnect from the controlling terminal by creating a new session.
 		// This prevents us from getting SIGINT when the user presses Ctrl-C


### PR DESCRIPTION
Logging, since we're on Linux/OSX/*BSD, should just be
a matter of switching the writer for the logging in tlog
and the default logger to the syslog one.  We need to,
however, do a .Dial call because .New appears to not
do what one intends- it doesn't establish a connection
to the syslog daemon unless you already have one from
.Dial

So, with that, we cleaned out the piped shell call to
logger, which adds to the overhead, isn't needed and
open up the UNIX domain socket hook to syslog with
log/syslog instead.  Seems to work for the cases
I needed for things.  Future iterations can accept
an option for -tcp/-udp and an IP address for
a network logging option if needed now.