### PR TITLE
Starting with fuse 3.0 the nonempty option has been removed.

### DIFF
--- a/cli_args.go
+++ b/cli_args.go
@@ -157,7 +157,7 @@ func parseCliOpts() (args argContainer) {
 		"Only works if user_allow_other is set in /etc/fuse.conf.")
 	flagSet.BoolVar(&args.reverse, "reverse", false, "Reverse mode")
 	flagSet.BoolVar(&args.aessiv, "aessiv", false, "AES-SIV encryption")
-	flagSet.BoolVar(&args.nonempty, "nonempty", false, "Allow mounting over non-empty directories")
+	flagSet.BoolVar(&args.nonempty, "nonempty", false, "Allow mounting over non-empty directories (deprecated for fuse >=3.0)")
 	flagSet.BoolVar(&args.raw64, "raw64", true, "Use unpadded base64 for file names")
 	flagSet.BoolVar(&args.noprealloc, "noprealloc", false, "Disable preallocation before writing")
 	flagSet.BoolVar(&args.speed, "speed", false, "Run crypto speed test")

--- a/mount.go
+++ b/mount.go
@@ -65,7 +65,9 @@ func doMount(args *argContainer) {
 		os.Exit(exitcodes.MountPoint)
 	}
 	major, _, err := ProgramVersion("fusermount")
-	os.Exit(exitcodes.Usage)
+	if err != nil {
+		os.Exit(exitcodes.Usage)
+	}
 	if args.nonempty {
 		if major > 2 {
 			tlog.Warn.Printf("The option \"nonempty\" was deprecated with fusermount version >= 3.0")


### PR DESCRIPTION
I ran into this problem in Ubuntu 20.04 beta.

The code for libfuse >= 3.0 had the nonempty mount option removed from fusermount because the standard mount option does not have this option.  This caused gocryptfs to fail when this option is used (fuse doesn't allow that option).  Not using it will not work either if the mountpoint is not empty because the check "isEmptyDir" failed.

http://fuse.996288.n3.nabble.com/ANNOUNCE-libfuse-3-0-0-has-been-released-td14403.html
