### PR TITLE
Update build script to use GOFLAGS and CGO_LDFLAGS

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -68,7 +68,7 @@ if [[ -n ${SOURCE_DATE_EPOCH:-} ]] ; then
 fi
 
 export GOFLAGS="${GOFLAGS:--buildmode=pie -trimpath}"
-export CGO_LDFLAGS="${CGO_LDFLAGS:-$LDFLAGS}"
+export CGO_LDFLAGS="${CGO_LDFLAGS:-${LDFLAGS:-}}"
 GO_LDFLAGS="-X main.GitVersion=$GITVERSION -X main.GitVersionFuse=$GITVERSIONFUSE -X main.BuildDate=$BUILDDATE"
 
 # Actual "go build" call for gocryptfs

--- a/build.bash
+++ b/build.bash
@@ -67,8 +67,8 @@ if [[ -n ${SOURCE_DATE_EPOCH:-} ]] ; then
 	BUILDDATE=$(date --utc --date="@${SOURCE_DATE_EPOCH}" +%Y-%m-%d)
 fi
 
-export GOFLAGS="-buildmode=pie -trimpath"
-export CGO_LDFLAGS="$LDFLAGS"
+export GOFLAGS="${GOFLAGS:--buildmode=pie -trimpath}"
+export CGO_LDFLAGS="${CGO_LDFLAGS:-$LDFLAGS}"
 GO_LDFLAGS="-X main.GitVersion=$GITVERSION -X main.GitVersionFuse=$GITVERSIONFUSE -X main.BuildDate=$BUILDDATE"
 
 # Actual "go build" call for gocryptfs


### PR DESCRIPTION
This change makes use of GOFLAGS to simplify compiling with PIE, respecting LDFLAGS and trimming local paths to support reproducible builds.

Relevant: https://lists.archlinux.org/pipermail/arch-dev-public/2020-March/029898.html

Since you are already providing a source tarball that includes vendor dependencies (👍), all dependency-related items in the email do not apply to you:

* -mod=vendor is used by default in Go 1.14
* -modcacherw is only needed if our build system was fetching vendor dependencies itself

Tested by applying this patch on top of 1.7.1 release archive that contains vendor folder.