### PR TITLE
contrib/getdents-debug: fix function call missing argument from 22e3eec

### DIFF
--- a/contrib/getdents-debug/getdents/getdents.go
+++ b/contrib/getdents-debug/getdents/getdents.go
@@ -66,7 +66,7 @@ func main() {
 		sum := 0
 		fd, err := unix.Open(path, unix.O_RDONLY, 0)
 		if err != nil {
-			fmt.Printf("%3d: unix.Open returned err=%v\n", err)
+			fmt.Printf("%3d: unix.Open returned err=%v\n", i, err)
 			os.Exit(1)
 		}
 		fmt.Printf("%3d: unix.Getdents: ", i)


### PR DESCRIPTION
22e3eec15302eac28c1a2ac3f9af29c2c9e82a3c build was broken with error message:
contrib/getdents-debug/getdents/getdents.go:69: Printf format %v reads arg 2, but call has 1 arg

This commit fixes it by adding the missing argument.

Edit: removed # from err msg so github doesnt link it to an issue #

