### PR TITLE
Fix wrong doc on exit code

### DIFF
--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -513,7 +513,7 @@ EXIT CODES
 ==========
 
 0: success  
-6: CIPHERDIR is not an empty directory (on "-init")  
+7: CIPHERDIR is not an empty directory (on "-init")  
 10: MOUNTPOINT is not an empty directory  
 12: password incorrect  
 22: password is empty (on "-init")  


### PR DESCRIPTION
According to real world tests, the correct exit code here is 7, so I'm updating the man page to avoid confusion.

See this session:

```bash
[root@132973203c5d /]# gocryptfs -init root
Invalid cipherdir: directory /root not empty
[root@132973203c5d /]# echo $?
7
[root@132973203c5d /]# gocryptfs --version
gocryptfs v1.8.0-Fedora-1.8.0-1.fc32; go-fuse 1.0.1; 2020-05-21 go1.14.2 linux/amd64
```