### PR TITLE
Add support for FIDO2 tokens

### DIFF
--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -130,6 +130,10 @@ to your program, use `"--"`, which is accepted by most programs:
 Stay in the foreground instead of forking away. Implies "-nosyslog".
 For compatibility, "-f" is also accepted, but "-fg" is preferred.
 
+#### -fido2 DEVICE_PATH
+Use a FIDO2 token to initialize and unlock the filesystem.
+Use "fido2-token -L" to obtain the FIDO2 token device path.
+
 #### -force_owner string
 If given a string of the form "uid:gid" (where both "uid" and "gid" are
 substituted with positive integers), presents all files as owned by the given

--- a/cli_args.go
+++ b/cli_args.go
@@ -32,7 +32,7 @@ type argContainer struct {
 	// Mount options with opposites
 	dev, nodev, suid, nosuid, exec, noexec, rw, ro bool
 	masterkey, mountpoint, cipherdir, cpuprofile,
-	memprofile, ko, ctlsock, fsname, force_owner, trace string
+	memprofile, ko, ctlsock, fsname, force_owner, trace, fido2 string
 	// -extpass, -badname, -passfile can be passed multiple times
 	extpass, badname, passfile multipleStrings
 	// For reverse mode, several ways to specify exclusions. All can be specified multiple times.
@@ -189,6 +189,7 @@ func parseCliOpts() (args argContainer) {
 	flagSet.StringVar(&args.fsname, "fsname", "", "Override the filesystem name")
 	flagSet.StringVar(&args.force_owner, "force_owner", "", "uid:gid pair to coerce ownership")
 	flagSet.StringVar(&args.trace, "trace", "", "Write execution trace to file")
+	flagSet.StringVar(&args.fido2, "fido2", "", "Protect the masterkey using a FIDO2 token instead of a password")
 
 	// Exclusion options
 	flagSet.Var(&args.exclude, "e", "Alias for -exclude")
@@ -277,6 +278,10 @@ func parseCliOpts() (args argContainer) {
 	}
 	if !args.extpass.Empty() && args.masterkey != "" {
 		tlog.Fatal.Printf("The options -extpass and -masterkey cannot be used at the same time")
+		os.Exit(exitcodes.Usage)
+	}
+	if !args.extpass.Empty() && args.fido2 != "" {
+		tlog.Fatal.Printf("The options -extpass and -fido2 cannot be used at the same time")
 		os.Exit(exitcodes.Usage)
 	}
 	if args.idle < 0 {

--- a/init_dir.go
+++ b/init_dir.go
@@ -9,7 +9,9 @@ import (
 	"syscall"
 
 	"github.com/rfjakob/gocryptfs/internal/configfile"
+	"github.com/rfjakob/gocryptfs/internal/cryptocore"
 	"github.com/rfjakob/gocryptfs/internal/exitcodes"
+	"github.com/rfjakob/gocryptfs/internal/fido2"
 	"github.com/rfjakob/gocryptfs/internal/nametransform"
 	"github.com/rfjakob/gocryptfs/internal/readpassword"
 	"github.com/rfjakob/gocryptfs/internal/syscallcompat"
@@ -67,14 +69,25 @@ func initDir(args *argContainer) {
 		}
 	}
 	// Choose password for config file
-	if args.extpass.Empty() {
+	if args.extpass.Empty() && args.fido2 == "" {
 		tlog.Info.Printf("Choose a password for protecting your files.")
 	}
 	{
-		password := readpassword.Twice([]string(args.extpass), []string(args.passfile))
+		var password []byte
+		var fido2CredentialID, fido2HmacSalt []byte
+		if args.fido2 != "" {
+			fido2CredentialID = fido2.Register(args.fido2, filepath.Base(args.cipherdir))
+			fido2HmacSalt = cryptocore.RandBytes(32)
+			password = fido2.Secret(args.fido2, fido2CredentialID, fido2HmacSalt)
+		} else {
+			// normal password entry
+			password = readpassword.Twice([]string(args.extpass), []string(args.passfile))
+			fido2CredentialID = nil
+			fido2HmacSalt = nil
+		}
 		creator := tlog.ProgramName + " " + GitVersion
 		err = configfile.Create(args.config, password, args.plaintextnames,
-			args.scryptn, creator, args.aessiv, args.devrandom)
+			args.scryptn, creator, args.aessiv, args.devrandom, args.fido2 != "", fido2CredentialID, fido2HmacSalt)
 		if err != nil {
 			tlog.Fatal.Println(err)
 			os.Exit(exitcodes.WriteConf)

--- a/internal/configfile/feature_flags.go
+++ b/internal/configfile/feature_flags.go
@@ -25,6 +25,9 @@ const (
 	// Note that this flag does not change the password hashing algorithm
 	// which always is scrypt.
 	FlagHKDF
+	// FlagFIDO2 means that "-fido2" was used when creating the filesystem.
+	// The masterkey is protected using a FIDO2 token instead of a password.
+	FlagFIDO2
 )
 
 // knownFlags stores the known feature flags and their string representation
@@ -37,6 +40,7 @@ var knownFlags = map[flagIota]string{
 	FlagAESSIV:         "AESSIV",
 	FlagRaw64:          "Raw64",
 	FlagHKDF:           "HKDF",
+	FlagFIDO2:          "FIDO2",
 }
 
 // Filesystems that do not have these feature flags set are deprecated.

--- a/internal/exitcodes/exitcodes.go
+++ b/internal/exitcodes/exitcodes.go
@@ -70,6 +70,8 @@ const (
 	ExcludeError = 29
 	// DevNull means that /dev/null could not be opened
 	DevNull = 30
+	// FIDO2Error - an error was encountered while interacting with a FIDO2 token
+	FIDO2Error = 31
 )
 
 // Err wraps an error with an associated numeric exit code

--- a/internal/fido2/fido2.go
+++ b/internal/fido2/fido2.go
@@ -1,0 +1,107 @@
+package fido2
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/rfjakob/gocryptfs/internal/cryptocore"
+	"github.com/rfjakob/gocryptfs/internal/exitcodes"
+	"github.com/rfjakob/gocryptfs/internal/tlog"
+)
+
+type fidoCommand int
+
+const (
+	cred          fidoCommand = iota
+	assert        fidoCommand = iota
+	assertWithPIN fidoCommand = iota
+)
+
+const relyingPartyID = "gocryptfs"
+
+func callFidoCommand(command fidoCommand, device string, stdin []string) ([]string, error) {
+	var cmd *exec.Cmd
+	switch command {
+	case cred:
+		cmd = exec.Command("fido2-cred", "-M", "-h", "-v", device)
+	case assert:
+		cmd = exec.Command("fido2-assert", "-G", "-h", device)
+	case assertWithPIN:
+		cmd = exec.Command("fido2-assert", "-G", "-h", "-v", device)
+	}
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range stdin {
+		io.WriteString(in, s+"\n")
+	}
+	in.Close()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(out), "\n"), nil
+}
+
+// Register registers a credential using a FIDO2 token
+func Register(device string, userName string) (credentialID []byte) {
+	fmt.Println("FIDO2 Register: interact with your device ...")
+	cdh := base64.StdEncoding.EncodeToString(cryptocore.RandBytes(32))
+	userID := base64.StdEncoding.EncodeToString(cryptocore.RandBytes(32))
+	stdin := []string{cdh, relyingPartyID, userName, userID}
+	out, err := callFidoCommand(cred, device, stdin)
+	if err != nil {
+		tlog.Fatal.Println(err)
+		os.Exit(exitcodes.FIDO2Error)
+	}
+	credentialID, err = base64.StdEncoding.DecodeString(out[4])
+	if err != nil {
+		tlog.Fatal.Println(err)
+		os.Exit(exitcodes.FIDO2Error)
+	}
+	return credentialID
+}
+
+// Secret generates a HMAC secret using a FIDO2 token
+func Secret(device string, credentialID []byte, salt []byte) (secret []byte) {
+	fmt.Println("FIDO2 Secret: interact with your device ...")
+	cdh := base64.StdEncoding.EncodeToString(cryptocore.RandBytes(32))
+	crid := base64.StdEncoding.EncodeToString(credentialID)
+	hmacsalt := base64.StdEncoding.EncodeToString(salt)
+	stdin := []string{cdh, relyingPartyID, crid, hmacsalt}
+	// try asserting without PIN first
+	out, err := callFidoCommand(assert, device, stdin)
+	if err != nil {
+		// if that fails, let's assert with PIN
+		out, err = callFidoCommand(assertWithPIN, device, stdin)
+		if err != nil {
+			tlog.Fatal.Println(err)
+			os.Exit(exitcodes.FIDO2Error)
+		}
+	}
+	secret, err = base64.StdEncoding.DecodeString(out[4])
+	if err != nil {
+		tlog.Fatal.Println(err)
+		os.Exit(exitcodes.FIDO2Error)
+	}
+
+	// sanity checks
+	secretLen := len(secret)
+	if secretLen < 32 {
+		tlog.Fatal.Printf("FIDO2 HMACSecret too short (%d)!\n", secretLen)
+		os.Exit(exitcodes.FIDO2Error)
+	}
+	zero := make([]byte, secretLen)
+	if bytes.Equal(zero, secret) {
+		tlog.Fatal.Printf("FIDO2 HMACSecret is all zero!")
+		os.Exit(exitcodes.FIDO2Error)
+	}
+
+	return secret
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rfjakob/gocryptfs/internal/configfile"
 	"github.com/rfjakob/gocryptfs/internal/contentenc"
 	"github.com/rfjakob/gocryptfs/internal/exitcodes"
+	"github.com/rfjakob/gocryptfs/internal/fido2"
 	"github.com/rfjakob/gocryptfs/internal/readpassword"
 	"github.com/rfjakob/gocryptfs/internal/speed"
 	"github.com/rfjakob/gocryptfs/internal/stupidgcm"
@@ -50,7 +51,16 @@ func loadConfig(args *argContainer) (masterkey []byte, cf *configfile.ConfFile, 
 	if masterkey != nil {
 		return masterkey, cf, nil
 	}
-	pw := readpassword.Once([]string(args.extpass), []string(args.passfile), "")
+	var pw []byte
+	if cf.IsFeatureFlagSet(configfile.FlagFIDO2) {
+		if args.fido2 == "" {
+			tlog.Fatal.Printf("Masterkey encrypted using FIDO2 token; need to use the --fido2 option.")
+			os.Exit(exitcodes.Usage)
+		}
+		pw = fido2.Secret(args.fido2, cf.FIDO2.CredentialID, cf.FIDO2.HMACSalt)
+	} else {
+		pw = readpassword.Once([]string(args.extpass), []string(args.passfile), "")
+	}
 	tlog.Info.Println("Decrypting master key")
 	masterkey, err = cf.DecryptMasterKey(pw)
 	for i := range pw {
@@ -77,6 +87,10 @@ func changePassword(args *argContainer) {
 		}
 		if len(masterkey) == 0 {
 			log.Panic("empty masterkey")
+		}
+		if confFile.IsFeatureFlagSet(configfile.FlagFIDO2) {
+			tlog.Fatal.Printf("Password change is not supported on FIDO2-enabled filesystems.")
+			os.Exit(exitcodes.Usage)
 		}
 		tlog.Info.Println("Please enter your new password.")
 		newPw := readpassword.Twice([]string(args.extpass), []string(args.passfile))


### PR DESCRIPTION
First implementation of https://github.com/rfjakob/gocryptfs/issues/504 - comments are welcome!

This introduces a new initialization option `-fido2` which uses a FIDO2 token (or more precisely FIDO2 HMAC Secret extension) instead of stdin to obtain the password.

Two interactions happen with the FIDO2 token during the initialization:

1) FIDO2 Registration - a token generates a `CredentialID`
2) FIDO2 Authentication - gocryptfs generates a random `HMACSalt` and asks the token to compute the `hmacSecret` using the salt and credential from the step 1 - this resulting secret is then used instead of the password

Config file contains three extra things when using FIDO2: `FeatureFlags.FlagFIDO2`, `FIDO2.CredentialID` and `FIDO2.HMACSalt`

During the mounting of the FS, only one interaction with the FIDO2 token is needed:
1) gocryptfs takes `FIDO2.CredentialID` and `FIDO2.HMACSalt` from the config and uses this to compue the `hmacSecret` via the token - this is exactly the same process as the second step in the init step above (so it produces the same secret)