### PR TITLE
Fix reverse gocryptfs.conf access on macOS

### DIFF
--- a/internal/fusefrontend_reverse/virtualconf.go
+++ b/internal/fusefrontend_reverse/virtualconf.go
@@ -10,6 +10,7 @@ import (
 )
 
 var _ = (fs.NodeOpener)((*VirtualConfNode)(nil))
+var _ = (fs.NodeGetattrer)((*VirtualConfNode)(nil))
 
 type VirtualConfNode struct {
 	fs.Inode
@@ -26,6 +27,17 @@ func (n *VirtualConfNode) Open(ctx context.Context, flags uint32) (fh fs.FileHan
 	fh = &VirtualConfFile{fd: fd}
 	return
 }
+
+func (n *VirtualConfNode) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	var st syscall.Stat_t
+	err := syscall.Stat(n.path, &st)
+	if err != nil {
+		return fs.ToErrno(err)
+	}
+	out.FromStat(&st)
+	return 0
+}
+
 
 // Check that we have implemented the fs.File* interfaces
 var _ = (fs.FileReader)((*VirtualConfFile)(nil))


### PR DESCRIPTION
Hey! There's a bug when using gocryptfs on macOS in reverse mode, where we can't access `gocryptfs.conf` in the virtual filesystem (supposed to map to `.gocryptfs.reverse.conf` in the real filesystem). It returns "Permission denied" instead.

FUSE debug logs looks like this when attempting to `cat gocryptfs.conf` in the virtual filesystem:

```
14:44:14.095207 rx 3: GETATTR n2
14:44:14.095229 tx 3:     OK, {tA=1s {M0100000 SZ=0 L=0 0:0 0 0:8954996 A 0.000000 M 0.000000 C 0.000000}}
14:44:14.099943 rx 4: ACCESS n2 {u=501 g=20 r}
14:44:14.099990 tx 4:     13=permission denied
```

I managed to fix it by implementing `Getattr` on `VirtualConfNode`.

Cheers!