### PR TITLE
Fix invalid -longnamemax for reverse mode

### DIFF
--- a/internal/fusefrontend_reverse/ctlsock_interface.go
+++ b/internal/fusefrontend_reverse/ctlsock_interface.go
@@ -26,7 +26,7 @@ func (rn *RootNode) EncryptPath(plainPath string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if rn.args.LongNames && len(encryptedPart) > unix.NAME_MAX {
+		if rn.args.LongNames && (len(encryptedPart) > unix.NAME_MAX || len(encryptedPart) > rn.nameTransform.GetLongNameMax()) {
 			encryptedPart = rn.nameTransform.HashLongName(encryptedPart)
 		}
 		cipherPath = filepath.Join(cipherPath, encryptedPart)

--- a/internal/fusefrontend_reverse/node_dir_ops.go
+++ b/internal/fusefrontend_reverse/node_dir_ops.go
@@ -73,7 +73,7 @@ func (n *Node) Readdir(ctx context.Context) (stream fs.DirStream, errno syscall.
 				entries[i].Name = "___GOCRYPTFS_INVALID_NAME___"
 				continue
 			}
-			if len(cName) > unix.NAME_MAX {
+			if len(cName) > unix.NAME_MAX || len(cName) > rn.nameTransform.GetLongNameMax() {
 				cName = rn.nameTransform.HashLongName(cName)
 				dotNameFile := fuse.DirEntry{
 					Mode: virtualFileMode,

--- a/internal/fusefrontend_reverse/root_node.go
+++ b/internal/fusefrontend_reverse/root_node.go
@@ -1,7 +1,6 @@
 package fusefrontend_reverse
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,7 +99,8 @@ func (rn *RootNode) findLongnameParent(fd int, diriv []byte, longname string) (p
 		}
 		if len(cFullName) <= unix.NAME_MAX && len(cFullName) <= rn.nameTransform.GetLongNameMax() {
 			// Entry should have been skipped by the shortNameMax check above
-			log.Panic("logic error or wrong shortNameMax constant?")
+			// log.Panic("logic error or wrong shortNameMax constant?")
+            continue
 		}
 		hName := rn.nameTransform.HashLongName(cFullName)
 		if longname == hName {

--- a/internal/fusefrontend_reverse/root_node.go
+++ b/internal/fusefrontend_reverse/root_node.go
@@ -42,6 +42,9 @@ type RootNode struct {
 	// rootDev stores the device number of the backing directory. Used for
 	// --one-file-system.
 	rootDev uint64
+	// If a file name length is shorter than shortNameMax, there is no need to
+	// hash it.
+	shortNameMax int
 }
 
 // NewRootNode returns an encrypted FUSE overlay filesystem.
@@ -66,6 +69,7 @@ func NewRootNode(args fusefrontend.Args, c *contentenc.ContentEnc, n *nametransf
 		contentEnc:    c,
 		inoMap:        inomap.New(rootDev),
 		rootDev:       rootDev,
+		shortNameMax:  (n.GetLongNameMax() - 20) * 3 / 4 - 1,
 	}
 	if len(args.Exclude) > 0 || len(args.ExcludeWildcard) > 0 || len(args.ExcludeFrom) > 0 {
 		rn.excluder = prepareExcluder(args)
@@ -87,14 +91,14 @@ func (rn *RootNode) findLongnameParent(fd int, diriv []byte, longname string) (p
 		return
 	}
 	for _, entry := range entries {
-		if len(entry.Name) <= shortNameMax {
+		if len(entry.Name) <= rn.shortNameMax {
 			continue
 		}
 		cFullName, err = rn.nameTransform.EncryptName(entry.Name, diriv)
 		if err != nil {
 			continue
 		}
-		if len(cFullName) <= unix.NAME_MAX {
+		if len(cFullName) <= unix.NAME_MAX && len(cFullName) <= rn.nameTransform.GetLongNameMax() {
 			// Entry should have been skipped by the shortNameMax check above
 			log.Panic("logic error or wrong shortNameMax constant?")
 		}

--- a/internal/nametransform/names.go
+++ b/internal/nametransform/names.go
@@ -167,3 +167,7 @@ func Dir(path string) string {
 	}
 	return d
 }
+
+func (n *NameTransform) GetLongNameMax() int {
+	return n.longNameMax
+}


### PR DESCRIPTION
In the reverse mode `-longnamemax` seems not working. Only encrypted file names longer than 255 are hashed.