### PR TITLE
Fix invalid -longnamemax for reverse mode

### DIFF
--- a/internal/fusefrontend_reverse/ctlsock_interface.go
+++ b/internal/fusefrontend_reverse/ctlsock_interface.go
@@ -26,7 +26,7 @@ func (rn *RootNode) EncryptPath(plainPath string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if rn.args.LongNames && len(encryptedPart) > unix.NAME_MAX {
+		if rn.args.LongNames && (len(encryptedPart) > unix.NAME_MAX || len(encryptedPart) > rn.nameTransform.GetLongNameMax()) {
 			encryptedPart = rn.nameTransform.HashLongName(encryptedPart)
 		}
 		cipherPath = filepath.Join(cipherPath, encryptedPart)

--- a/internal/fusefrontend_reverse/node_dir_ops.go
+++ b/internal/fusefrontend_reverse/node_dir_ops.go
@@ -73,7 +73,7 @@ func (n *Node) Readdir(ctx context.Context) (stream fs.DirStream, errno syscall.
 				entries[i].Name = "___GOCRYPTFS_INVALID_NAME___"
 				continue
 			}
-			if len(cName) > unix.NAME_MAX {
+			if len(cName) > unix.NAME_MAX || len(cName) > rn.nameTransform.GetLongNameMax() {
 				cName = rn.nameTransform.HashLongName(cName)
 				dotNameFile := fuse.DirEntry{
 					Mode: virtualFileMode,

--- a/internal/nametransform/names.go
+++ b/internal/nametransform/names.go
@@ -168,6 +168,8 @@ func Dir(path string) string {
 	return d
 }
 
+// GetLongNameMax will return curent `longNameMax`. File name longer than
+// this should be hashed.
 func (n *NameTransform) GetLongNameMax() int {
 	return n.longNameMax
 }

--- a/internal/nametransform/names.go
+++ b/internal/nametransform/names.go
@@ -167,3 +167,7 @@ func Dir(path string) string {
 	}
 	return d
 }
+
+func (n *NameTransform) GetLongNameMax() int {
+	return n.longNameMax
+}


### PR DESCRIPTION
In the reverse mode `-longnamemax` seems not working. Only encrypted file names longer than 255 are hashed.