### PR TITLE
Use existing build information for version if not embedded with build script

### DIFF
--- a/init_dir.go
+++ b/init_dir.go
@@ -55,6 +55,8 @@ func isDir(dir string) error {
 // In reverse mode, we create .gocryptfs.reverse.conf and the directory does
 // not need to be empty.
 func initDir(args *argContainer) {
+	initGIT()
+
 	var err error
 	if args.reverse {
 		_, err = os.Stat(args.config)


### PR DESCRIPTION
Go1.12 introduced BuildInfo which embeds build information. It does not embed build date to facilitate reproducable builds by default. If build information is embedded from build script, use the information provided by the Go build system.

Closes #687