### PR TITLE
Print errors to stderr

### DIFF
--- a/gocryptfs-xray/paths_ctlsock.go
+++ b/gocryptfs-xray/paths_ctlsock.go
@@ -22,7 +22,7 @@ func transformPaths(socketPath string, req *ctlsock.RequestStruct, in *string, s
 	errorCount := 0
 	c, err := ctlsock.New(socketPath)
 	if err != nil {
-		fmt.Printf("fatal: %v\n", err)
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		os.Exit(1)
 	}
 	line := 1

--- a/gocryptfs-xray/xray_main.go
+++ b/gocryptfs-xray/xray_main.go
@@ -107,7 +107,7 @@ func main() {
 
 	s := sum(args.dumpmasterkey, args.decryptPaths, args.encryptPaths)
 	if s > 1 {
-		fmt.Printf("fatal: %d operations were requested\n", s)
+		fmt.Fprintf(os.Stderr, "fatal: %d operations were requested\n", s)
 		os.Exit(1)
 	}
 	if flag.NArg() != 1 {
@@ -183,7 +183,7 @@ func inspectCiphertext(args *argContainer, fd *os.File) {
 		fmt.Println("empty file")
 		os.Exit(0)
 	} else if err == io.EOF {
-		fmt.Printf("incomplete file header: read %d bytes, want %d\n", n, contentenc.HeaderLen)
+		fmt.Fprintf(os.Stderr, "incomplete file header: read %d bytes, want %d\n", n, contentenc.HeaderLen)
 		os.Exit(1)
 	} else if err != nil {
 		errExit(err)


### PR DESCRIPTION
gocryptfs-xray writes error output to stdout instead of stderr, which complicates it's usage in scripts.

This patch redirects error output to stderr.