### PR TITLE
Build with v2 extensions

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -85,6 +85,9 @@ if [[ -n ${LDFLAGS:-} ]] ; then
 	GO_LDFLAGS="$GO_LDFLAGS \"-extldflags=$LDFLAGS\""
 fi
 
+# Set GOAMD64 version to v2
+export GOAMD64=v2
+
 # Actual "go build" call for gocryptfs
 go build "-ldflags=$GO_LDFLAGS" "$@"
 # Additional binaries


### PR DESCRIPTION
Enables older CPUs (2008-2013) to take advantage of certain hardware accelerators.

Closes #828