### PR TITLE
manpage: Fix reference to manual section

### DIFF
--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -381,7 +381,7 @@ Mount the filesystem read-write (`-rw`, default) or read-only (`-ro`).
 If both are specified, `-ro` takes precedence.
 
 #### -reverse
-See the `-reverse` section in INIT FLAGS. You need to specify the
+See the `-reverse` section in INIT OPTIONS. You need to specify the
 `-reverse` option both at `-init` and at mount.
 
 #### -serialize_reads


### PR DESCRIPTION
The `--reverse` section of the manual has a reference to an `INIT FLAGS` section, but no such section exists. Change the reference to refer to the `INIT OPTIONS` section, which does exist.