### PR TITLE
Feature: offer to create mountpoint if it does not exist

### DIFF
--- a/cli_args.go
+++ b/cli_args.go
@@ -31,7 +31,7 @@ type argContainer struct {
 	longnames, allow_other, reverse, aessiv, nonempty, raw64,
 	noprealloc, speed, hkdf, serialize_reads, hh, info,
 	sharedstorage, fsck, one_file_system, deterministic_names,
-	xchacha bool
+	xchacha, mkdir bool
 	// Mount options with opposites
 	dev, nodev, suid, nosuid, exec, noexec, rw, ro, kernel_cache, acl bool
 	masterkey, mountpoint, cipherdir, cpuprofile,
@@ -188,6 +188,8 @@ func parseCliOpts(osArgs []string) (args argContainer) {
 	flagSet.BoolVar(&args.one_file_system, "one-file-system", false, "Don't cross filesystem boundaries")
 	flagSet.BoolVar(&args.deterministic_names, "deterministic-names", false, "Disable diriv file name randomisation")
 	flagSet.BoolVar(&args.xchacha, "xchacha", false, "Use XChaCha20-Poly1305 file content encryption")
+	flagSet.BoolVar(&args.mkdir, "mkdir", false, "Create mountpoint if it does not already exist")
+	flagSet.BoolVar(&args.mkdir, "m", false, "");
 
 	// Mount options with opposites
 	flagSet.BoolVar(&args.dev, "dev", false, "Allow device files")

--- a/help.go
+++ b/help.go
@@ -31,6 +31,7 @@ Common Options (use -hh to show all):
   -init              Initialize encrypted directory
   -info              Display information about encrypted directory
   -masterkey         Mount with explicit master key instead of password
+  -mkdir             Create mountpoint if it does not already exist
   -nonempty          Allow mounting over non-empty directory
   -nosyslog          Do not redirect log messages to syslog
   -passfile          Read password from plain text file(s)

--- a/mount.go
+++ b/mount.go
@@ -63,6 +63,20 @@ func doMount(args *argContainer) {
 			args.mountpoint, args.cipherdir)
 		os.Exit(exitcodes.MountPoint)
 	}
+	// Create directory if option mkdir has been typed
+	// Checking whether the mountpoint path exists, regardless of whether it is
+	// a directory or a regular file
+	_, err = os.Stat(args.mountpoint)
+	if os.IsNotExist(err) {
+		if args.mkdir {
+			err = os.MkdirAll(args.mountpoint, 0700)
+			if err != nil {
+				tlog.Fatal.Printf("Failed to create mountpoint: %v", err)
+				os.Exit(exitcodes.MountPoint)
+			}
+			tlog.Info.Printf(tlog.ColorGreen + "Mountpoint %q created." + tlog.ColorReset, args.mountpoint)
+		}
+	}
 	if args.nonempty {
 		err = isDir(args.mountpoint)
 	} else if strings.HasPrefix(args.mountpoint, "/dev/fd/") {


### PR DESCRIPTION
Hi.

I have used Gocryptfs many times and I have missed that the mount directory, often temporary, is created automatically in case it does not exist. That is why I am suggesting the option `mkdir` here, if you consider it suitable.

If have tested it and it seems to work fine:

~~~
$ ./gocryptfs -mkdir ciphdir /tmp/x
Mountpoint "/tmp/x" created.
Password:
~~~

If you would like to change anything or you have any preference, please feel free to let me know. For example, I have used `mkdirAll` , but a more cautious option would be `mkdir` instead.

I am an amateur developer and I am not a Go expert. In case something is wrong, I am available to correct it.

Kind regards,
Lucas.