### PR TITLE
Fix issue with reverse mode and excluded virtual files (#686)

### DIFF
--- a/internal/fusefrontend_reverse/node_helpers.go
+++ b/internal/fusefrontend_reverse/node_helpers.go
@@ -134,7 +134,7 @@ func (n *Node) lookupLongnameName(ctx context.Context, nameFile string, out *fus
 	if errno != 0 {
 		return
 	}
-	if rn.isExcludedPlain(filepath.Join(d.cPath, pName)) {
+	if rn.isExcludedPlain(filepath.Join(d.pPath, pName)) {
 		errno = syscall.EPERM
 		return
 	}

--- a/internal/fusefrontend_reverse/root_node.go
+++ b/internal/fusefrontend_reverse/root_node.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 
+	"github.com/rfjakob/gocryptfs/v2/internal/configfile"
 	"github.com/rfjakob/gocryptfs/v2/internal/contentenc"
 	"github.com/rfjakob/gocryptfs/v2/internal/exitcodes"
 	"github.com/rfjakob/gocryptfs/v2/internal/fusefrontend"
@@ -136,7 +137,8 @@ func (rn *RootNode) findLongnameParent(fd int, diriv []byte, longname string) (p
 // excluded (used when -exclude is passed by the user).
 func (rn *RootNode) isExcludedPlain(pPath string) bool {
 	// root dir can't be excluded
-	if pPath == "" {
+	// Don't exclude gocryptfs.conf too
+	if pPath == "" || pPath == configfile.ConfReverseName {
 		return false
 	}
 	return rn.excluder != nil && rn.excluder.MatchesPath(pPath)


### PR DESCRIPTION
This fixes #686. Now the `gocryptfs.longname.*.name` are present and readable in the reverse mount, regardless of the complexity of the exclusion patterns.

The main issue was a `cPath` instead of `dPath` for the exclude check in `fusefrontend_reverse/node_helpers.go`. Also added a check to avoid the exclusion of `gocryptfs.conf` in the root directory.

The test run results are in line with the main branch. 
