### PR TITLE
fusefrontend: reuse readdir names for READDIRPLUS

### DIFF
--- a/internal/fusefrontend/file_dir_ops.go
+++ b/internal/fusefrontend/file_dir_ops.go
@@ -65,6 +65,7 @@ func (n *Node) OpendirHandle(ctx context.Context, flags uint32) (fh fs.FileHandl
 		ds:        ds,
 		dirIV:     dirIV,
 		isRootDir: n.IsRoot(),
+		node:      n,
 	}
 
 	return file, fuseFlags, errno
@@ -91,6 +92,18 @@ type DirHandle struct {
 
 	// fs.loopbackDirStream with a private dup of the file descriptor
 	ds fs.FileHandle
+
+	// lastName and lastCName are the plaintext and raw ciphertext names from
+	// the last entry returned by Readdirent. go-fuse's READDIRPLUS bridge
+	// serializes Readdirent, Lookup, and Seekdir on each file handle.
+	//
+	// Keep this mapping across calls: go-fuse may carry an overflow entry into
+	// the next READDIRPLUS request without calling Readdirent again.
+	lastName  string
+	lastCName string
+
+	// Node this directory handle was opened from.
+	node *Node
 }
 
 var _ = (fs.FileReleasedirer)((*File)(nil))
@@ -105,7 +118,13 @@ func (f *File) Releasedir(ctx context.Context, flags uint32) {
 var _ = (fs.FileSeekdirer)((*File)(nil))
 
 func (f *File) Seekdir(ctx context.Context, off uint64) syscall.Errno {
-	return f.dirHandle.ds.(fs.FileSeekdirer).Seekdir(ctx, off)
+	errno := f.dirHandle.ds.(fs.FileSeekdirer).Seekdir(ctx, off)
+	if errno == 0 {
+		// Readdirent will repopulate the mapping at the new position.
+		f.dirHandle.lastName = ""
+		f.dirHandle.lastCName = ""
+	}
+	return errno
 }
 
 var _ = (fs.FileFsyncdirer)((*File)(nil))
@@ -115,6 +134,11 @@ func (f *File) Fsyncdir(ctx context.Context, flags uint32) syscall.Errno {
 }
 
 var _ = (fs.FileReaddirenter)((*File)(nil))
+
+func (f *File) rememberName(name string, cName string) {
+	f.dirHandle.lastName = name
+	f.dirHandle.lastCName = cName
+}
 
 // This function is symlink-safe through use of openBackingDir() and
 // ReadDirIVAt().
@@ -128,7 +152,12 @@ func (f *File) Readdirent(ctx context.Context) (entry *fuse.DirEntry, errno sysc
 			return
 		}
 
-		cName := entry.Name
+		// Preserve the name that exists on disk. For long names, cName below is
+		// replaced with the full ciphertext name from the .name sidecar, which
+		// is only the input for decryption.
+		rawCName := entry.Name
+		cName := rawCName
+		lookupCName := rawCName
 		if cName == "." || cName == ".." {
 			// We want these as-is
 			return
@@ -138,6 +167,7 @@ func (f *File) Readdirent(ctx context.Context) (entry *fuse.DirEntry, errno sysc
 			continue
 		}
 		if f.rootNode.args.PlaintextNames {
+			f.rememberName(cName, rawCName)
 			return
 		}
 		if !f.rootNode.args.DeterministicNames && cName == nametransform.DirIVFilename {
@@ -157,10 +187,23 @@ func (f *File) Readdirent(ctx context.Context) (entry *fuse.DirEntry, errno sysc
 				f.rootNode.reportMitigatedCorruption(cName)
 				continue
 			}
+			// A mismatched sidecar is corrupt. Preserve Node.Lookup semantics
+			// by falling back to its canonical re-encryption and hashing.
+			if f.rootNode.nameTransform.HashLongName(cNameLong) != rawCName ||
+				len(cNameLong) <= f.rootNode.nameTransform.GetLongNameMax() {
+				tlog.Warn.Printf("Readdirent: noncanonical long-name entry %q", rawCName)
+				f.rootNode.reportMitigatedCorruption(rawCName)
+				lookupCName = ""
+			}
 			cName = cNameLong
 		} else if isLong == nametransform.LongNameFilename {
 			// ignore "gocryptfs.longname.*.name"
 			continue
+		} else if len(rawCName) > f.rootNode.nameTransform.GetLongNameMax() {
+			// The canonical form of this name is hashed.
+			tlog.Warn.Printf("Readdirent: noncanonical unhashed name %q", rawCName)
+			f.rootNode.reportMitigatedCorruption(rawCName)
+			lookupCName = ""
 		}
 		name, err := f.rootNode.nameTransform.DecryptName(cName, f.dirHandle.dirIV)
 		if err != nil {
@@ -172,6 +215,36 @@ func (f *File) Readdirent(ctx context.Context) (entry *fuse.DirEntry, errno sysc
 		// Override the ciphertext name with the plaintext name but reuse the rest
 		// of the structure
 		entry.Name = name
+		f.rememberName(name, lookupCName)
 		return
 	}
+}
+
+var _ = (fs.FileLookuper)((*File)(nil))
+
+// Lookup implements fs.FileLookuper for READDIRPLUS. Readdirent has already
+// translated name and retained the exact backing name, so the common path can
+// avoid translating the name again and obtaining another directory fd.
+func (f *File) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (ch *fs.Inode, errno syscall.Errno) {
+	f.fdLock.RLock()
+	if f.released {
+		f.fdLock.RUnlock()
+		return nil, syscall.EBADF
+	}
+
+	f.rootNode.IsIdle.Store(false)
+
+	if name != f.dirHandle.lastName ||
+		f.dirHandle.lastCName == "" ||
+		f.rootNode.nameTransform.HaveBadnamePatterns() {
+		// go-fuse can replay entries without calling Readdirent after an
+		// interrupted read. The retained mapping may not belong to name then.
+		// Badname mappings can also be ambiguous, and corrupt long-name
+		// sidecars must go through canonical name translation.
+		f.fdLock.RUnlock()
+		return f.dirHandle.node.Lookup(ctx, name, out)
+	}
+
+	defer f.fdLock.RUnlock()
+	return f.dirHandle.node.lookupChild(ctx, name, f.intFd(), f.dirHandle.lastCName, out)
 }

--- a/internal/fusefrontend/file_dir_ops_test.go
+++ b/internal/fusefrontend/file_dir_ops_test.go
@@ -1,0 +1,369 @@
+package fusefrontend
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/rfjakob/gocryptfs/v2/internal/nametransform"
+)
+
+func newFileLookupFS(t *testing.T, args Args, longNameMax uint8) (*RootNode, []byte) {
+	t.Helper()
+
+	args.Cipherdir = t.TempDir()
+	var dirIV []byte
+	if !args.PlaintextNames && !args.DeterministicNames {
+		dirIV = make([]byte, nametransform.DirIVLen)
+		dirIV[0] = 1
+		err := os.WriteFile(filepath.Join(args.Cipherdir, nametransform.DirIVFilename), dirIV, 0400)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return newTestFSWithLongNameMax(args, longNameMax), dirIV
+}
+
+func createFileForLookup(t *testing.T, args Args, name string) (rn *RootNode, rawCName string) {
+	t.Helper()
+
+	rn, _ = newFileLookupFS(t, args, 0)
+	_, fh, _, errno := rn.Create(context.Background(), name, syscall.O_WRONLY, 0600, &fuse.EntryOut{})
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	if errno = fh.(*File).Release(context.Background()); errno != 0 {
+		t.Fatal(errno)
+	}
+
+	entries, err := os.ReadDir(rn.args.Cipherdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		cName := entry.Name()
+		if cName != nametransform.DirIVFilename &&
+			nametransform.NameType(cName) != nametransform.LongNameFilename {
+			rawCName = cName
+			break
+		}
+	}
+	if rawCName == "" {
+		t.Fatal("could not find ciphertext content file")
+	}
+	return rn, rawCName
+}
+
+func openFileLookupDir(t *testing.T, rn *RootNode) *File {
+	t.Helper()
+
+	fh, _, errno := rn.OpendirHandle(context.Background(), 0)
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	file := fh.(*File)
+	t.Cleanup(func() {
+		file.Releasedir(context.Background(), 0)
+	})
+	return file
+}
+
+func readDirForFileLookup(t *testing.T, rn *RootNode, name string) *File {
+	t.Helper()
+
+	file := openFileLookupDir(t, rn)
+
+	for {
+		entry, errno := file.Readdirent(context.Background())
+		if errno != 0 {
+			t.Fatal(errno)
+		}
+		if entry == nil {
+			t.Fatalf("did not find %q in directory", name)
+		}
+		if entry.Name == name {
+			return file
+		}
+	}
+}
+
+func openDirForFileLookup(t *testing.T, args Args, name string) (rn *RootNode, file *File, rawCName string) {
+	t.Helper()
+
+	rn, rawCName = createFileForLookup(t, args, name)
+	file = readDirForFileLookup(t, rn, name)
+	return rn, file, rawCName
+}
+
+func TestFileLookupUsesRawCiphertextName(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+		name     string
+		args     Args
+	}{
+		{"short", "short", Args{LongNames: true}},
+		{"long", strings.Repeat("l", 200), Args{LongNames: true}},
+		{"plaintextnames", "plaintext", Args{PlaintextNames: true}},
+		{"deterministic", "deterministic", Args{LongNames: true, DeterministicNames: true}},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			rn, file, rawCName := openDirForFileLookup(t, tc.args, tc.name)
+
+			if file.dirHandle.lastName != tc.name {
+				t.Fatalf("lastName=%q, want %q", file.dirHandle.lastName, tc.name)
+			}
+			if file.dirHandle.lastCName != rawCName {
+				t.Fatalf("lastCName=%q, want raw directory entry %q", file.dirHandle.lastCName, rawCName)
+			}
+
+			out := &fuse.EntryOut{}
+			child, errno := file.Lookup(context.Background(), tc.name, out)
+			if errno != 0 {
+				t.Fatal(errno)
+			}
+			if child == nil || out.Mode&syscall.S_IFMT != syscall.S_IFREG {
+				t.Fatalf("unexpected lookup result: child=%v mode=%#o", child, out.Mode)
+			}
+
+			nodeOut := &fuse.EntryOut{}
+			nodeChild, errno := rn.Lookup(context.Background(), tc.name, nodeOut)
+			if errno != 0 {
+				t.Fatal(errno)
+			}
+			if child.StableAttr() != nodeChild.StableAttr() || out.Attr != nodeOut.Attr {
+				t.Fatalf("File.Lookup and Node.Lookup differ:\nfile=%+v %#v\nnode=%+v %#v",
+					child.StableAttr(), out.Attr, nodeChild.StableAttr(), nodeOut.Attr)
+			}
+		})
+	}
+}
+
+func TestFileLookupSymlinkMatchesNodeLookup(t *testing.T) {
+	const (
+		name   = "link"
+		target = "relative/target"
+	)
+	rn, _ := newFileLookupFS(t, Args{LongNames: true}, 0)
+	_, errno := rn.Symlink(context.Background(), target, name, &fuse.EntryOut{})
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	file := readDirForFileLookup(t, rn, name)
+
+	fileOut := &fuse.EntryOut{}
+	fileChild, errno := file.Lookup(context.Background(), name, fileOut)
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	nodeOut := &fuse.EntryOut{}
+	nodeChild, errno := rn.Lookup(context.Background(), name, nodeOut)
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	fileAttr := fileOut.Attr
+	nodeAttr := nodeOut.Attr
+	fileAttr.Atime, fileAttr.Atimensec = 0, 0
+	nodeAttr.Atime, nodeAttr.Atimensec = 0, 0
+	if fileChild.StableAttr() != nodeChild.StableAttr() || fileAttr != nodeAttr {
+		t.Fatalf("File.Lookup and Node.Lookup differ:\nfile=%+v %#v\nnode=%+v %#v",
+			fileChild.StableAttr(), fileAttr, nodeChild.StableAttr(), nodeAttr)
+	}
+	if fileOut.Size != uint64(len(target)) {
+		t.Fatalf("symlink size=%d, want %d", fileOut.Size, len(target))
+	}
+}
+
+func TestFileLookupFastPath(t *testing.T) {
+	name := "file"
+	rn, file, _ := openDirForFileLookup(t, Args{LongNames: true}, name)
+
+	// Make Node.Lookup fail while leaving the open directory handle usable.
+	// File.Lookup can now succeed only through the retained-name fast path.
+	rn.dirCache.Clear()
+	if err := os.Remove(filepath.Join(rn.args.Cipherdir, nametransform.DirIVFilename)); err != nil {
+		t.Fatal(err)
+	}
+
+	child, errno := file.Lookup(context.Background(), name, &fuse.EntryOut{})
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	if child == nil {
+		t.Fatal("fast-path lookup returned a nil child")
+	}
+}
+
+func TestFileLookupRejectsNoncanonicalLongName(t *testing.T) {
+	name := "short"
+	rn, rawCName := createFileForLookup(t, Args{LongNames: true}, name)
+
+	// Store a short ciphertext through the long-name representation. Both
+	// entries decrypt to name, but only rawCName is canonical.
+	hashName := rn.nameTransform.HashLongName(rawCName)
+	if err := os.WriteFile(filepath.Join(rn.args.Cipherdir, hashName), nil, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rn.args.Cipherdir, hashName+nametransform.LongNameSuffix),
+		[]byte(rawCName), 0400); err != nil {
+		t.Fatal(err)
+	}
+
+	file := openFileLookupDir(t, rn)
+	for {
+		entry, errno := file.Readdirent(context.Background())
+		if errno != 0 {
+			t.Fatal(errno)
+		}
+		if entry == nil {
+			t.Fatalf("did not find noncanonical entry for %q", name)
+		}
+		if entry.Name == name && file.dirHandle.lastCName == "" {
+			break
+		}
+	}
+
+	out := &fuse.EntryOut{}
+	_, errno := file.Lookup(context.Background(), name, out)
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	if out.Mode&0777 != 0600 {
+		t.Fatalf("lookup used noncanonical mode %#o, want 0600", out.Mode&0777)
+	}
+}
+
+func TestFileLookupRejectsUnhashedLongName(t *testing.T) {
+	const longNameMax = 100
+	name := strings.Repeat("n", 80)
+	rn, dirIV := newFileLookupFS(t, Args{LongNames: true}, longNameMax)
+	rawCName, err := rn.nameTransform.EncryptName(name, dirIV)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rawCName) <= longNameMax {
+		t.Fatalf("ciphertext name has length %d, want > %d", len(rawCName), longNameMax)
+	}
+	if err := os.WriteFile(filepath.Join(rn.args.Cipherdir, rawCName), nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	rn.MitigatedCorruptions = make(chan string, 1)
+
+	file := readDirForFileLookup(t, rn, name)
+	if file.dirHandle.lastCName != "" {
+		t.Fatalf("retained noncanonical unhashed name %q", file.dirHandle.lastCName)
+	}
+	select {
+	case got := <-rn.MitigatedCorruptions:
+		if got != rawCName {
+			t.Fatalf("reported corruption %q, want %q", got, rawCName)
+		}
+	default:
+		t.Fatal("noncanonical unhashed name was not reported as corruption")
+	}
+	child, errno := file.Lookup(context.Background(), name, &fuse.EntryOut{})
+	if errno != syscall.ENOENT || child != nil {
+		t.Fatalf("lookup result: child=%v errno=%v, want nil, ENOENT", child, errno)
+	}
+}
+
+func TestFileLookupRejectsMismatchedLongNameSidecar(t *testing.T) {
+	name := strings.Repeat("l", 200)
+	rn, rawCName := createFileForLookup(t, Args{LongNames: true}, name)
+
+	otherName := "other"
+	dirIV, err := os.ReadFile(filepath.Join(rn.args.Cipherdir, nametransform.DirIVFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cName, err := rn.nameTransform.EncryptName(otherName, dirIV)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sidecar := filepath.Join(rn.args.Cipherdir, rawCName+nametransform.LongNameSuffix)
+	if err := os.Chmod(sidecar, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sidecar, []byte(cName), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	file := readDirForFileLookup(t, rn, otherName)
+	if file.dirHandle.lastCName != "" {
+		t.Fatalf("retained noncanonical ciphertext name %q", file.dirHandle.lastCName)
+	}
+	child, errno := file.Lookup(context.Background(), otherName, &fuse.EntryOut{})
+	if errno != syscall.ENOENT || child != nil {
+		t.Fatalf("lookup result: child=%v errno=%v, want nil, ENOENT", child, errno)
+	}
+}
+
+func TestFileLookupFallsBackAfterSeek(t *testing.T) {
+	name := "file"
+	_, file, _ := openDirForFileLookup(t, Args{LongNames: true}, name)
+
+	if errno := file.Seekdir(context.Background(), 0); errno != 0 {
+		t.Fatal(errno)
+	}
+	if file.dirHandle.lastName != "" || file.dirHandle.lastCName != "" {
+		t.Fatal("Seekdir did not clear the retained name mapping")
+	}
+
+	child, errno := file.Lookup(context.Background(), name, &fuse.EntryOut{})
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	if child == nil {
+		t.Fatal("fallback lookup returned a nil child")
+	}
+}
+
+func TestFileLookupResetsIdleMarker(t *testing.T) {
+	name := "file"
+	rn, file, _ := openDirForFileLookup(t, Args{LongNames: true}, name)
+
+	rn.IsIdle.Store(true)
+	_, errno := file.Lookup(context.Background(), name, &fuse.EntryOut{})
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	if rn.IsIdle.Load() {
+		t.Fatal("File.Lookup did not reset the idle marker")
+	}
+}
+
+func TestFileLookupPreservesLookupBehavior(t *testing.T) {
+	name := "file"
+	owner := fuse.Owner{Uid: 1234, Gid: 5678}
+	rn, file, _ := openDirForFileLookup(t, Args{
+		ForceOwner:    &owner,
+		LongNames:     true,
+		SharedStorage: true,
+	}, name)
+
+	out := &fuse.EntryOut{}
+	child, errno := file.Lookup(context.Background(), name, out)
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	if out.Owner != owner {
+		t.Fatalf("owner=%v, want %v", out.Owner, owner)
+	}
+
+	rn.AddChild(name, child, false)
+	out = &fuse.EntryOut{}
+	child2, errno := file.Lookup(context.Background(), name, out)
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	if child2 != child {
+		t.Fatal("-sharedstorage lookup did not reuse the existing child")
+	}
+	if out.Owner != owner {
+		t.Fatalf("owner=%v, want %v", out.Owner, owner)
+	}
+}

--- a/internal/fusefrontend/node.go
+++ b/internal/fusefrontend/node.go
@@ -28,6 +28,12 @@ func (n *Node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (ch 
 	}
 	defer syscall.Close(dirfd)
 
+	return n.lookupChild(ctx, name, dirfd, cName, out)
+}
+
+// lookupChild looks up name using an already-open backing directory and the
+// corresponding ciphertext name.
+func (n *Node) lookupChild(ctx context.Context, name string, dirfd int, cName string, out *fuse.EntryOut) (ch *fs.Inode, errno syscall.Errno) {
 	// Get device number and inode number into `st`
 	st, err := syscallcompat.Fstatat2(dirfd, cName, unix.AT_SYMLINK_NOFOLLOW)
 	if err != nil {

--- a/internal/fusefrontend/root_node.go
+++ b/internal/fusefrontend/root_node.go
@@ -40,9 +40,8 @@ type RootNode struct {
 	// "gocryptfs -fsck" reads from the channel to also catch these transparently-
 	// mitigated corruptions.
 	MitigatedCorruptions chan string
-	// IsIdle flag is set to zero each time fs.isFiltered() is called
-	// (uint32 so that it can be reset with CompareAndSwapUint32).
-	// When -idle was used when mounting, idleMonitor() sets it to 1
+	// IsIdle is set to false on each filesystem operation.
+	// When -idle was used when mounting, idleMonitor() sets it to true
 	// periodically.
 	IsIdle atomic.Bool
 	// dirCache caches directory fds

--- a/internal/fusefrontend/xattr_unit_test.go
+++ b/internal/fusefrontend/xattr_unit_test.go
@@ -15,11 +15,15 @@ import (
 )
 
 func newTestFS(args Args) *RootNode {
+	return newTestFSWithLongNameMax(args, 0)
+}
+
+func newTestFSWithLongNameMax(args Args, longNameMax uint8) *RootNode {
 	// Init crypto backend
 	key := make([]byte, cryptocore.KeyLen)
 	cCore := cryptocore.New(key, cryptocore.BackendGoGCM, contentenc.DefaultIVBits, true)
 	cEnc := contentenc.New(cCore, contentenc.DefaultBS)
-	n := nametransform.New(cCore.EMECipher, true, 0, true, nil, false)
+	n := nametransform.New(cCore.EMECipher, true, longNameMax, true, nil, args.DeterministicNames)
 	rn := NewRootNode(args, cEnc, n)
 	oneSecond := time.Second
 	options := &fs.Options{


### PR DESCRIPTION
## Summary

Implement `fs.FileLookuper` on forward-mode directory handles so `READDIRPLUS` can reuse the name translation and backing directory file descriptor already available in `Readdirent`.

The common path now avoids repeating the directory-cache lookup, fd duplication, plaintext-name validation, and EME encryption for every listed entry. It still performs the backing `fstatat`, creates the go-fuse inode, and returns the same attributes as `Node.Lookup`.

Refs #1026.

## Correctness

The directory handle retains only the most recently returned plaintext-to-raw-ciphertext mapping:

- The mapping survives across requests for go-fuse's overflow-entry handling.
- A seek clears it.
- Interrupted-read replay or any name mismatch falls back to `Node.Lookup`.
- Long names retain the hashed name that actually exists on disk, not the full ciphertext stored in the `.name` sidecar.
- Noncanonical long-name representations fall back to `Node.Lookup` and are reported as mitigated corruption.
- `-badname` always uses the existing `Node.Lookup` path because its reverse mapping can be ambiguous.
- `ForceOwner`, `-sharedstorage` child reuse, symlink size translation, and idle-monitor activity are preserved.

## Benchmarks

Each measurement used a fresh read-only gocryptfs process and `ls -U -1A`. Variant order was alternated. The baseline was commit `790362e`; the test variant was this branch.

On an NFS-backed directory containing 1,000,000 short, empty files, across five runs:

- Median wall time: 23.86 s → 18.83 s (21% lower).
- Median gocryptfs CPU time: 11.58 s → 9.11 s (21% lower).
- Wall-time ranges were 20.43–32.10 s and 6.90–30.99 s respectively. The wide range reflects changes in NFS metadata-cache state.

On a local directory containing 100,000 short, empty files, across five runs:

- Median wall time: 0.78 s → 0.66 s (15% lower).
- Median gocryptfs CPU time: 0.80 s → 0.63 s (21% lower).

This optimization does not remove the per-entry `fstatat`, inode creation, memory use, or larger `READDIRPLUS` response records. Disabling `READDIRPLUS` remains a separate proposal.

## Test plan

- [x] `go test ./...`
- [x] `go test -race -count=1 ./internal/fusefrontend`
- [x] `go test -count=20 ./internal/fusefrontend -run 'TestFileLookup'`
- [x] `go vet ./...`
- [x] Fresh-mount NFS benchmark against the pre-change commit
- [x] Fresh-mount local-storage benchmark against the pre-change commit
