### PR TITLE
Use READDIR by default and add -readdirplus

### DIFF
--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -378,6 +378,9 @@ metadata-heavy workloads such as `ls -l`. With the default cache
 timeouts (that is, without `-sharedstorage`), `ls -l` was 36% slower
 on local storage and 82% slower in a single NFS run.
 
+`-sharedstorage` implies `-noreaddirplus` and this cannot be
+overridden.
+
 This option currently only has an effect on Linux.
 
 For benchmarks and more details, see
@@ -434,7 +437,7 @@ Enable work-arounds so gocryptfs works better when the backing
 storage directory is concurrently accessed by multiple gocryptfs
 instances.
 
-At the moment, it does two things:
+At the moment, it does three things:
 
 1. Disable stat() caching so changes to the backing storage show up
    immediately.
@@ -442,6 +445,11 @@ At the moment, it does two things:
    storage are not stable when files are deleted and re-created behind
    our back. This would otherwise produce strange "file does not exist"
    and other errors.
+3. Disable FUSE `READDIRPLUS`, because its eagerly fetched attributes
+   cannot be reused by the kernel's attribute cache when stat caching
+   is disabled. The backing filesystem may still cache attributes.
+   On network backing storage, metadata-heavy directory listings may
+   become slower.
 
 When "-sharedstorage" is active, performance is reduced and hard
 links cannot be created.

--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -366,6 +366,23 @@ out-of-space errors for a massive speedup.
 For benchmarks and more details of the issue see
 https://github.com/rfjakob/gocryptfs/issues/63 .
 
+#### -noreaddirplus
+Disable FUSE `READDIRPLUS`. By default, Linux may request attributes
+for every entry during a directory listing. This improves workloads
+that immediately inspect most entries, but adds unnecessary work to
+names-only listings.
+
+This option restores demand-driven behavior: attributes are fetched
+only when the application requests them. It can substantially slow
+metadata-heavy workloads such as `ls -l`. With the default cache
+timeouts (that is, without `-sharedstorage`), `ls -l` was 36% slower
+on local storage and 82% slower in a single NFS run.
+
+This option currently only has an effect on Linux.
+
+For benchmarks and more details, see
+https://github.com/rfjakob/gocryptfs/issues/1026 .
+
 #### -nosuid
 See `-suid, -nosuid`.
 

--- a/Documentation/MANPAGE.md
+++ b/Documentation/MANPAGE.md
@@ -366,26 +366,6 @@ out-of-space errors for a massive speedup.
 For benchmarks and more details of the issue see
 https://github.com/rfjakob/gocryptfs/issues/63 .
 
-#### -noreaddirplus
-Disable FUSE `READDIRPLUS`. By default, Linux may request attributes
-for every entry during a directory listing. This improves workloads
-that immediately inspect most entries, but adds unnecessary work to
-names-only listings.
-
-This option restores demand-driven behavior: attributes are fetched
-only when the application requests them. It can substantially slow
-metadata-heavy workloads such as `ls -l`. With the default cache
-timeouts (that is, without `-sharedstorage`), `ls -l` was 36% slower
-on local storage and 82% slower in a single NFS run.
-
-`-sharedstorage` implies `-noreaddirplus` and this cannot be
-overridden.
-
-This option currently only has an effect on Linux.
-
-For benchmarks and more details, see
-https://github.com/rfjakob/gocryptfs/issues/1026 .
-
 #### -nosuid
 See `-suid, -nosuid`.
 
@@ -405,6 +385,32 @@ Mountpoints will appear as empty directories.
 Only applicable to reverse mode.
 
 Limitation: Mounted single files (yes this is possible) are NOT hidden.
+
+#### -readdirplus
+Enable FUSE `READDIRPLUS` on Linux. It is disabled by default, so
+attributes are fetched only when an application requests them.
+
+`READDIRPLUS` requests attributes for every entry during a directory
+listing. This can improve metadata-heavy workloads such as `ls -l`,
+but adds unnecessary work to names-only listings. With the default
+cache timeouts (without `-sharedstorage`), enabling `READDIRPLUS` made
+metadata-heavy listings 1.36x faster in a local 100,000-file directory
+and 1.82x faster in a single run over a 1,000,000-file NFS directory.
+It made names-only listings 6.5x and 18.2x slower respectively.
+
+The default also applies to reverse mode. Backup and synchronization
+tools that inspect metadata for most entries may benefit from
+`-readdirplus`.
+
+This option can also be combined with `-sharedstorage`. Because that
+mode disables kernel attribute caching, whether `READDIRPLUS` helps
+depends on the workload and backing storage.
+
+On platforms other than Linux, this option is accepted but has no
+effect.
+
+For benchmarks and more details, see
+https://github.com/rfjakob/gocryptfs/issues/1026 .
 
 #### -rw, -ro
 Mount the filesystem read-write (`-rw`, default) or read-only (`-ro`).
@@ -437,7 +443,7 @@ Enable work-arounds so gocryptfs works better when the backing
 storage directory is concurrently accessed by multiple gocryptfs
 instances.
 
-At the moment, it does three things:
+At the moment, it does two things:
 
 1. Disable stat() caching so changes to the backing storage show up
    immediately.
@@ -445,11 +451,6 @@ At the moment, it does three things:
    storage are not stable when files are deleted and re-created behind
    our back. This would otherwise produce strange "file does not exist"
    and other errors.
-3. Disable FUSE `READDIRPLUS`, because its eagerly fetched attributes
-   cannot be reused by the kernel's attribute cache when stat caching
-   is disabled. The backing filesystem may still cache attributes.
-   On network backing storage, metadata-heavy directory listings may
-   become slower.
 
 When "-sharedstorage" is active, performance is reduced and hard
 links cannot be created.

--- a/cli_args.go
+++ b/cli_args.go
@@ -29,7 +29,7 @@ type argContainer struct {
 	debug, init, zerokey, fusedebug, openssl, passwd, fg, version,
 	plaintextnames, quiet, nosyslog, wpanic,
 	longnames, allow_other, reverse, aessiv, nonempty, raw64,
-	noprealloc, noreaddirplus, speed, hkdf, serialize_reads, hh, info,
+	noprealloc, readdirplus, speed, hkdf, serialize_reads, hh, info,
 	sharedstorage, fsck, one_file_system, deterministic_names,
 	xchacha, noxattr bool
 	// Mount options with opposites
@@ -178,7 +178,7 @@ func parseCliOpts(osArgs []string) (args argContainer) {
 	flagSet.BoolVar(&args.nonempty, "nonempty", false, "Allow mounting over non-empty directories")
 	flagSet.BoolVar(&args.raw64, "raw64", true, "Use unpadded base64 for file names")
 	flagSet.BoolVar(&args.noprealloc, "noprealloc", false, "Disable preallocation before writing")
-	flagSet.BoolVar(&args.noreaddirplus, "noreaddirplus", false, "Disable FUSE READDIRPLUS")
+	flagSet.BoolVar(&args.readdirplus, "readdirplus", false, "Enable FUSE READDIRPLUS (Linux only)")
 	flagSet.BoolVar(&args.speed, "speed", false, "Run crypto speed test")
 	flagSet.BoolVar(&args.hkdf, "hkdf", true, "Use HKDF as an additional key derivation step")
 	flagSet.BoolVar(&args.serialize_reads, "serialize_reads", false, "Try to serialize read operations")

--- a/cli_args.go
+++ b/cli_args.go
@@ -29,7 +29,7 @@ type argContainer struct {
 	debug, init, zerokey, fusedebug, openssl, passwd, fg, version,
 	plaintextnames, quiet, nosyslog, wpanic,
 	longnames, allow_other, reverse, aessiv, nonempty, raw64,
-	noprealloc, speed, hkdf, serialize_reads, hh, info,
+	noprealloc, noreaddirplus, speed, hkdf, serialize_reads, hh, info,
 	sharedstorage, fsck, one_file_system, deterministic_names,
 	xchacha, noxattr bool
 	// Mount options with opposites
@@ -178,6 +178,7 @@ func parseCliOpts(osArgs []string) (args argContainer) {
 	flagSet.BoolVar(&args.nonempty, "nonempty", false, "Allow mounting over non-empty directories")
 	flagSet.BoolVar(&args.raw64, "raw64", true, "Use unpadded base64 for file names")
 	flagSet.BoolVar(&args.noprealloc, "noprealloc", false, "Disable preallocation before writing")
+	flagSet.BoolVar(&args.noreaddirplus, "noreaddirplus", false, "Disable FUSE READDIRPLUS")
 	flagSet.BoolVar(&args.speed, "speed", false, "Run crypto speed test")
 	flagSet.BoolVar(&args.hkdf, "hkdf", true, "Use HKDF as an additional key derivation step")
 	flagSet.BoolVar(&args.serialize_reads, "serialize_reads", false, "Try to serialize read operations")

--- a/cli_args_test.go
+++ b/cli_args_test.go
@@ -157,13 +157,13 @@ func TestParseCliOpts(t *testing.T) {
 	}...)
 
 	o = defaultArgs
-	o.noreaddirplus = true
+	o.readdirplus = true
 	testcases = append(testcases, []testcaseContainer{
 		{
-			i: []string{"gocryptfs", "-noreaddirplus"},
+			i: []string{"gocryptfs", "-readdirplus"},
 			o: o,
 		}, {
-			i: []string{"gocryptfs", "-o", "noreaddirplus"},
+			i: []string{"gocryptfs", "-o", "readdirplus"},
 			o: o,
 		},
 	}...)

--- a/cli_args_test.go
+++ b/cli_args_test.go
@@ -157,6 +157,18 @@ func TestParseCliOpts(t *testing.T) {
 	}...)
 
 	o = defaultArgs
+	o.noreaddirplus = true
+	testcases = append(testcases, []testcaseContainer{
+		{
+			i: []string{"gocryptfs", "-noreaddirplus"},
+			o: o,
+		}, {
+			i: []string{"gocryptfs", "-o", "noreaddirplus"},
+			o: o,
+		},
+	}...)
+
+	o = defaultArgs
 	o.exclude = []string{"foo", "bar", "baz,boe"}
 	testcases = append(testcases, []testcaseContainer{
 		{

--- a/mount.go
+++ b/mount.go
@@ -364,10 +364,7 @@ type RootInoer interface {
 // adds mount-specific values.
 func baseMountOptions(args *argContainer) fuse.MountOptions {
 	return fuse.MountOptions{
-		// With -sharedstorage, attribute and entry caching is disabled, so the
-		// attributes returned by READDIRPLUS cannot be reused by the kernel's
-		// attribute cache.
-		DisableReadDirPlus: args.noreaddirplus || args.sharedstorage,
+		DisableReadDirPlus: !args.readdirplus,
 		// Writes and reads are usually capped at 128kiB on Linux through
 		// the FUSE_MAX_PAGES_PER_REQ kernel constant in fuse_i.h. Our
 		// sync.Pool buffer pools are sized acc. to the default. Users may set

--- a/mount.go
+++ b/mount.go
@@ -364,7 +364,10 @@ type RootInoer interface {
 // adds mount-specific values.
 func baseMountOptions(args *argContainer) fuse.MountOptions {
 	return fuse.MountOptions{
-		DisableReadDirPlus: args.noreaddirplus,
+		// With -sharedstorage, attribute and entry caching is disabled, so the
+		// attributes returned by READDIRPLUS cannot be reused by the kernel's
+		// attribute cache.
+		DisableReadDirPlus: args.noreaddirplus || args.sharedstorage,
 		// Writes and reads are usually capped at 128kiB on Linux through
 		// the FUSE_MAX_PAGES_PER_REQ kernel constant in fuse_i.h. Our
 		// sync.Pool buffer pools are sized acc. to the default. Users may set

--- a/mount.go
+++ b/mount.go
@@ -360,6 +360,33 @@ type RootInoer interface {
 	RootIno() uint64
 }
 
+// baseMountOptions returns the mount options that are set before initGoFuse
+// adds mount-specific values.
+func baseMountOptions(args *argContainer) fuse.MountOptions {
+	return fuse.MountOptions{
+		DisableReadDirPlus: args.noreaddirplus,
+		// Writes and reads are usually capped at 128kiB on Linux through
+		// the FUSE_MAX_PAGES_PER_REQ kernel constant in fuse_i.h. Our
+		// sync.Pool buffer pools are sized acc. to the default. Users may set
+		// the kernel constant higher, and Synology NAS kernels are known to
+		// have it >128kiB. We cannot handle more than 128kiB, so we tell
+		// the kernel to limit the size explicitly.
+		MaxWrite: fuse.MAX_KERNEL_WRITE,
+		Debug:    args.fusedebug,
+		// The kernel usually submits multiple read requests in parallel,
+		// which means we serve them in any order. Out-of-order reads are
+		// expensive on some backing network filesystems
+		// ( https://github.com/rfjakob/gocryptfs/issues/92 ).
+		//
+		// Setting SyncRead disables FUSE_CAP_ASYNC_READ. This makes the kernel
+		// do everything in-order without parallelism.
+		SyncRead: args.serialize_reads,
+		// Attempt to directly call mount(2) before trying fusermount. This means we
+		// can do without fusermount if running as root.
+		DirectMount: true,
+	}
+}
+
 // initGoFuse calls into go-fuse to mount `rootNode` on `args.mountpoint`.
 // The mountpoint is ready to use when the functions returns.
 // On error, it calls os.Exit and does not return.
@@ -389,27 +416,7 @@ func initGoFuse(rootNode fs.InodeEmbedder, args *argContainer) *fuse.Server {
 	fuseOpts.RootStableAttr = &fs.StableAttr{Ino: rootNode.(RootInoer).RootIno()}
 	// Enable go-fuse warnings
 	fuseOpts.Logger = log.New(os.Stderr, "go-fuse: ", log.Lmicroseconds)
-	fuseOpts.MountOptions = fuse.MountOptions{
-		// Writes and reads are usually capped at 128kiB on Linux through
-		// the FUSE_MAX_PAGES_PER_REQ kernel constant in fuse_i.h. Our
-		// sync.Pool buffer pools are sized acc. to the default. Users may set
-		// the kernel constant higher, and Synology NAS kernels are known to
-		// have it >128kiB. We cannot handle more than 128kiB, so we tell
-		// the kernel to limit the size explicitly.
-		MaxWrite: fuse.MAX_KERNEL_WRITE,
-		Debug:    args.fusedebug,
-		// The kernel usually submits multiple read requests in parallel,
-		// which means we serve them in any order. Out-of-order reads are
-		// expensive on some backing network filesystems
-		// ( https://github.com/rfjakob/gocryptfs/issues/92 ).
-		//
-		// Setting SyncRead disables FUSE_CAP_ASYNC_READ. This makes the kernel
-		// do everything in-order without parallelism.
-		SyncRead: args.serialize_reads,
-		// Attempt to directly call mount(2) before trying fusermount. This means we
-		// can do without fusermount if running as root.
-		DirectMount: true,
-	}
+	fuseOpts.MountOptions = baseMountOptions(args)
 
 	mOpts := &fuseOpts.MountOptions
 	opts := make(map[string]string)

--- a/mount_test.go
+++ b/mount_test.go
@@ -6,14 +6,18 @@ func TestDisableReadDirPlus(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		noreaddirplus bool
+		sharedstorage bool
 		want          bool
 	}{
 		{name: "default"},
 		{name: "noreaddirplus", noreaddirplus: true, want: true},
+		{name: "sharedstorage", sharedstorage: true, want: true},
+		{name: "both", noreaddirplus: true, sharedstorage: true, want: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			args := &argContainer{
 				noreaddirplus: tc.noreaddirplus,
+				sharedstorage: tc.sharedstorage,
 			}
 			got := baseMountOptions(args).DisableReadDirPlus
 			if got != tc.want {

--- a/mount_test.go
+++ b/mount_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestDisableReadDirPlus(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		noreaddirplus bool
+		want          bool
+	}{
+		{name: "default"},
+		{name: "noreaddirplus", noreaddirplus: true, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := &argContainer{
+				noreaddirplus: tc.noreaddirplus,
+			}
+			got := baseMountOptions(args).DisableReadDirPlus
+			if got != tc.want {
+				t.Fatalf("DisableReadDirPlus=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/mount_test.go
+++ b/mount_test.go
@@ -5,18 +5,19 @@ import "testing"
 func TestDisableReadDirPlus(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
-		noreaddirplus bool
+		readdirplus   bool
 		sharedstorage bool
 		want          bool
 	}{
-		{name: "default"},
-		{name: "noreaddirplus", noreaddirplus: true, want: true},
-		{name: "sharedstorage", sharedstorage: true, want: true},
-		{name: "both", noreaddirplus: true, sharedstorage: true, want: true},
+		{name: "default", want: true},
+		{name: "readdirplus", readdirplus: true},
+		// -sharedstorage does not override an explicit -readdirplus.
+		{name: "sharedstorage-default", sharedstorage: true, want: true},
+		{name: "sharedstorage-readdirplus", readdirplus: true, sharedstorage: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			args := &argContainer{
-				noreaddirplus: tc.noreaddirplus,
+				readdirplus:   tc.readdirplus,
 				sharedstorage: tc.sharedstorage,
 			}
 			got := baseMountOptions(args).DisableReadDirPlus

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -991,11 +991,11 @@ func TestInitNotEmpty(t *testing.T) {
 	}
 }
 
-// TestNoreaddirplus checks that mounting and listing work with -noreaddirplus.
-func TestNoreaddirplus(t *testing.T) {
+// TestReaddirplus checks that mounting and listing work with -readdirplus.
+func TestReaddirplus(t *testing.T) {
 	dir := test_helpers.InitFS(t)
 	mnt := dir + ".mnt"
-	test_helpers.MountOrFatal(t, dir, mnt, "-extpass=echo test", "-noreaddirplus")
+	test_helpers.MountOrFatal(t, dir, mnt, "-extpass=echo test", "-readdirplus")
 	defer test_helpers.UnmountPanic(mnt)
 
 	if err := os.WriteFile(mnt+"/file", nil, 0600); err != nil {

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -991,6 +991,25 @@ func TestInitNotEmpty(t *testing.T) {
 	}
 }
 
+// TestNoreaddirplus checks that mounting and listing work with -noreaddirplus.
+func TestNoreaddirplus(t *testing.T) {
+	dir := test_helpers.InitFS(t)
+	mnt := dir + ".mnt"
+	test_helpers.MountOrFatal(t, dir, mnt, "-extpass=echo test", "-noreaddirplus")
+	defer test_helpers.UnmountPanic(mnt)
+
+	if err := os.WriteFile(mnt+"/file", nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(mnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "file" {
+		t.Fatalf("unexpected directory entries: %v", entries)
+	}
+}
+
 // TestSharedstorage checks that `-sharedstorage` shows stable inode numbers to
 // userspace despite having hard link tracking disabled
 func TestSharedstorage(t *testing.T) {

--- a/tests/matrix/main_test.go
+++ b/tests/matrix/main_test.go
@@ -59,6 +59,7 @@ func TestMain(m *testing.M) {
 		{false, "auto", false, true, nil},
 		// -serialize_reads
 		{false, "auto", false, false, []string{"-serialize_reads"}},
+		{false, "auto", false, false, []string{"-noreaddirplus"}},
 		{false, "auto", false, false, []string{"-sharedstorage"}},
 		{false, "auto", false, false, []string{"-deterministic-names"}},
 		// Test xchacha with and without openssl

--- a/tests/matrix/main_test.go
+++ b/tests/matrix/main_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 		{false, "auto", false, true, nil},
 		// -serialize_reads
 		{false, "auto", false, false, []string{"-serialize_reads"}},
-		{false, "auto", false, false, []string{"-noreaddirplus"}},
+		{false, "auto", false, false, []string{"-readdirplus"}},
 		{false, "auto", false, false, []string{"-sharedstorage"}},
 		{false, "auto", false, false, []string{"-deterministic-names"}},
 		// Test xchacha with and without openssl


### PR DESCRIPTION
## Summary

- Disable FUSE `READDIRPLUS` negotiation by default.
- Add `-readdirplus` to opt back into `READDIRPLUS`.
- Apply the same default to forward and reverse mounts.
- Document the performance trade-off and exercise both directory-reading modes in the test matrix.

Related to #1026. This PR is independent of #1027 and does not depend on its `FileLookuper` optimization.

## Rationale

go-fuse negotiates `READDIRPLUS` by default. It asks gocryptfs to look up every directory entry while enumerating it, even when an application only requested names. For large directories this adds per-entry name translation, backing-store metadata operations, inode allocation, CPU time, and memory use.

This PR sets `fuse.MountOptions.DisableReadDirPlus` by default, restoring demand-driven behavior: applications that only enumerate names avoid eager lookups, while applications that need metadata request it separately. `-readdirplus` retains the previous behavior for metadata-heavy workloads.

The earlier version of this PR made `-sharedstorage` imply `-noreaddirplus`. That special case is no longer needed because plain `READDIR` is now the global default. An explicit `-sharedstorage -readdirplus` enables `READDIRPLUS`; whether that helps depends on the workload and backing storage because `-sharedstorage` disables kernel attribute caching.

The default also applies to reverse mode. Backup and synchronization workloads that inspect metadata for most entries may benefit from `-readdirplus`.

## Performance trade-off

The benchmarks do not show a universally better fixed setting. Plain `READDIR` makes names-only listings 6.5–18.2× faster, while `READDIRPLUS` makes metadata-heavy listings 1.36–1.82× faster with the default cache timeouts.

The names-only improvement is much larger, and plain `READDIR` avoids metadata work until an application asks for it. Users whose workloads inspect metadata for most entries can restore the previous behavior with `-readdirplus`.

`READDIRPLUS_AUTO` would not fully address the original workload because it always starts each opened directory with `READDIRPLUS`. The real workload contains thousands of mostly small directories that fit in the first response.

## Benchmarks

All measurements are forward mode and used a fresh read-only gocryptfs process. Variant order was alternated. Names-only listings used `ls -U -1A`; metadata-heavy listings used `ls -lA`. The comparison is `-readdirplus` → default `READDIR`. Peak RSS was sampled from `/proc` every 50 ms. Values are medians except where noted as a single run.

Default cache timeouts:

| Backing | Files | Workload | Runs | Elapsed time | gocryptfs CPU time | Peak memory (RSS) |
| --- | ---: | --- | ---: | --- | --- | --- |
| NFS | 1,000,000 | Names only (`ls -U -1A`) | 3 | 20.21 s → 1.11 s (18.2× faster) | 10.54 s → 1.00 s (10.5× better) | 623,604 → 28,316 KiB (22.0× better) |
| Local | 100,000 | Names only (`ls -U -1A`) | 5 | 0.78 s → 0.12 s (6.5× faster) | 0.74 s → 0.10 s (7.4× better) | 69,292 → 21,260 KiB (3.3× better) |
| Local | 100,000 | Metadata-heavy (`ls -lA`) | 5 | 3.25 s → 4.42 s (1.36× slower) | 2.57 s → 3.25 s (1.26× worse) | — |
| NFS | 1,000,000 | Metadata-heavy (`ls -lA`) | 1 | 209.84 s → 381.87 s (1.82× slower) | 68.74 s → 112.78 s (1.64× worse) | — |

With `-sharedstorage`, the comparison is `-sharedstorage -readdirplus` → default `-sharedstorage`:

| Backing | Files | Workload | Runs | Elapsed time | gocryptfs CPU time | Peak memory (RSS) |
| --- | ---: | --- | ---: | --- | --- | --- |
| Local | 100,000 | Names only (`ls -U -1A`) | 5 | 1.00 s → 0.19 s (5.3× faster) | 1.01 s → 0.18 s (5.6× better) | 75,696 → 21,412 KiB (3.5× better) |
| Local | 100,000 | Metadata-heavy (`ls -lA`) | 5 | 18.46 s → 16.44 s (1.12× faster) | 14.20 s → 12.35 s (1.15× better) | 96,784 → 89,416 KiB (1.08× better) |
| NFS | 1,000,000 | Metadata-heavy (`ls -lA`) | 1 | 560.21 s → 629.56 s (1.12× slower) | 306.89 s → 278.10 s (1.10× better) | 537,848 → 763,736 KiB (1.42× worse) |

The NFS metadata-heavy figures are single runs, so they should not be treated as stable point estimates. They show the potential trade-off: plain `READDIR` can lose NFS bulk-attribute locality and make metadata-heavy shared-storage listings slower. The 1.42× worse peak-memory result on that single NFS run is unexplained.

## Test plan

- `go test -count=1 ./...`
- `go vet ./...`
- Added CLI parsing coverage for both `-readdirplus` and `-o readdirplus`.
- Added mount-option coverage for the default, explicit `-readdirplus`, and `-sharedstorage -readdirplus`.
- The normal test matrix now exercises plain `READDIR`; an explicit `-readdirplus` variant preserves `READDIRPLUS` coverage.
- Manually verified on Linux 6.18 with `-fusedebug` that the FUSE INIT reply omits `READDIRPLUS` by default and advertises it with `-readdirplus`, including in combination with `-sharedstorage`.
