### PR TITLE
fusefrontend: take ContentLock for truncate through node.Setattr

### DIFF
--- a/internal/fusefrontend/file_allocate_truncate.go
+++ b/internal/fusefrontend/file_allocate_truncate.go
@@ -96,7 +96,27 @@ func (f *File) Allocate(ctx context.Context, off uint64, sz uint64, mode uint32)
 	return f.truncateGrowFile(oldPlainSz, newPlainSz)
 }
 
+// truncateLocked takes the locks that truncate needs and truncates.
+//
+// truncate calls doWrite, which requires ContentLock to be held by the caller.
+// file.Setattr already holds it; node.Setattr (the path used by truncate(2))
+// opens a fresh file handle and has nothing around it, so it goes through here.
+func (f *File) truncateLocked(newSize uint64) syscall.Errno {
+	f.fdLock.RLock()
+	defer f.fdLock.RUnlock()
+	if f.released {
+		tlog.Warn.Printf("ino%d fh%d: truncate on released file", f.qIno.Ino, f.intFd())
+		return syscall.EBADF
+	}
+	f.fileTableEntry.ContentLock.Lock()
+	defer f.fileTableEntry.ContentLock.Unlock()
+
+	return f.truncate(newSize)
+}
+
 // truncate - called from node.Setattr and file.Setattr.
+//
+// The caller must hold ContentLock, see truncateLocked.
 func (f *File) truncate(newSize uint64) (errno syscall.Errno) {
 	var err error
 	// Common case first: Truncate to zero

--- a/internal/fusefrontend/issue_1024_test.go
+++ b/internal/fusefrontend/issue_1024_test.go
@@ -1,0 +1,116 @@
+package fusefrontend
+
+// Regression test for https://github.com/rfjakob/gocryptfs/issues/1024
+//
+// truncate(2) goes through node.Setattr, which opens its own file handle. That
+// handle must take ContentLock like file.Setattr does: the lock doubles as the
+// global write-operation counter that isConsecutiveWrite() uses to notice that
+// somebody else changed the file. Without it, an already-open handle keeps
+// believing its next write appends, skips writePadHole(), and leaves the last
+// block short while the file grows past it - the block then fails to decrypt.
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/rfjakob/gocryptfs/v2/internal/contentenc"
+	"github.com/rfjakob/gocryptfs/v2/internal/cryptocore"
+	"github.com/rfjakob/gocryptfs/v2/internal/nametransform"
+)
+
+// issue1024Fs sets up a fusefrontend root over a temporary directory.
+func issue1024Fs(t *testing.T) (*RootNode, string) {
+	t.Helper()
+
+	cipherdir := t.TempDir()
+	key := make([]byte, cryptocore.KeyLen)
+	cCore := cryptocore.New(key, cryptocore.BackendGoGCM, contentenc.DefaultIVBits, true)
+	cEnc := contentenc.New(cCore, contentenc.DefaultBS)
+	nt := nametransform.New(cCore.EMECipher, true, 255, true, nil, false)
+
+	return NewRootNode(Args{Cipherdir: cipherdir}, cEnc, nt), filepath.Join(cipherdir, "backing")
+}
+
+// issue1024Open opens path as a File, like node.Open would.
+func issue1024Open(t *testing.T, rn *RootNode, path string, flags int) *File {
+	t.Helper()
+
+	fd, err := syscall.Open(path, flags, 0600)
+	if err != nil {
+		t.Fatalf("open %q: %v", path, err)
+	}
+	f, _, errno := NewFile(fd, path, rn)
+	if errno != 0 {
+		t.Fatalf("NewFile: %v", errno)
+	}
+	t.Cleanup(func() {
+		if !f.released {
+			_ = f.Release(context.Background())
+		}
+	})
+
+	return f
+}
+
+func TestTruncateThroughSecondHandleKeepsBlocksValid(t *testing.T) {
+	rn, path := issue1024Fs(t)
+	ctx := context.Background()
+
+	// The handle the application keeps open, as in the issue's reproducer.
+	f := issue1024Open(t, rn, path, syscall.O_RDWR|syscall.O_CREAT|syscall.O_EXCL)
+
+	block := make([]byte, contentenc.DefaultBS)
+	for i := range block {
+		block[i] = byte(i)
+	}
+	if _, errno := f.Write(ctx, block, 0); errno != 0 {
+		t.Fatalf("write of a full block: %v", errno)
+	}
+
+	// truncate(2): node.Setattr opens a second handle for the truncate and
+	// closes it again. The application's handle stays open and keeps its
+	// file offset, which is why the next write lands past the new size.
+	shrink := func(size uint64) {
+		t.Helper()
+		f2 := issue1024Open(t, rn, path, syscall.O_RDWR)
+		if errno := f2.truncateLocked(size); errno != 0 {
+			t.Fatalf("truncate(%d): %v", size, errno)
+		}
+		if errno := f2.Release(ctx); errno != 0 {
+			t.Fatalf("release: %v", errno)
+		}
+	}
+
+	shrink(8)
+
+	payload := []byte("Test data!")
+	if _, errno := f.Write(ctx, payload, int64(contentenc.DefaultBS)); errno != 0 {
+		t.Fatalf("write past the new EOF: %v", errno)
+	}
+
+	// The write created a hole, so the first block had to be padded. If it was
+	// not, it is now short and no longer decrypts.
+	got, errno := f.doRead(nil, 0, contentenc.DefaultBS)
+	if errno != 0 {
+		t.Fatalf("reading the first block: %v", errno)
+	}
+	want := append(block[:8], bytes.Repeat([]byte{0}, contentenc.DefaultBS-8)...)
+	if !bytes.Equal(got, want) {
+		t.Errorf("first block: got %d bytes, want %d zero-padded bytes", len(got), len(want))
+	}
+
+	// The payload is still readable at its offset.
+	got, errno = f.doRead(nil, uint64(contentenc.DefaultBS), uint64(len(payload)))
+	if errno != 0 {
+		t.Fatalf("reading the payload: %v", errno)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("payload: got %q, want %q", got, payload)
+	}
+
+	// And shrinking again works, which is where the issue reported EIO.
+	shrink(7)
+}

--- a/internal/fusefrontend/node.go
+++ b/internal/fusefrontend/node.go
@@ -246,7 +246,7 @@ func (n *Node) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn,
 		}
 		f2 := f.(*File)
 		defer f2.Release(ctx)
-		errno = syscall.Errno(f2.truncate(sz))
+		errno = syscall.Errno(f2.truncateLocked(sz))
 		if errno != 0 {
 			return errno
 		}


### PR DESCRIPTION
Fixes #1024.

`truncate(2)` reaches `node.Setattr`, which opens its own file handle and calls `f2.truncate(sz)` directly (`internal/fusefrontend/node.go:249`). `file.Setattr` does the same work while holding `ContentLock` (`file_setattr.go:29`), and `Allocate` holds it too (`file_allocate_truncate.go:58`) — the node path is the only caller that does not, although `truncate` ends in `doWrite`, whose comment states the caller has locked it.

Two things follow from the missing lock, and the second is what the issue reports:

1. A path truncate is not serialized against concurrent writes to the same file.
2. `ContentLock.Lock()` is what increments the global write-operation counter (`openfiletable.countingMutex.Lock`). `isConsecutiveWrite` uses that counter to notice that somebody else touched the file since this handle's last write. A truncate through the node path leaves the counter untouched, so an already-open handle still thinks its next write appends, skips `writePadHole`, and grows the file past a short last block. The block keeps the authentication tag of its old length and no longer decrypts:

```
doRead 543573: corrupt block #0: cipher: message authentication failed
```

That is the reporter's sequence exactly: write 4096 bytes, `truncate(file, 8)` (the descriptor keeps its offset of 4096), write 10 bytes — which now lands past the new EOF — and every later read, write or truncate of that file fails with EIO.

The fix adds `truncateLocked`, which takes `fdLock`/`ContentLock` and then calls `truncate`, and has `node.Setattr` use it. `file.Setattr` and `Allocate` keep their existing locking, so nothing takes the lock twice.

Verified without a mount: `internal/fusefrontend/issue_1024_test.go` drives the File methods against a backing file and repeats the reporter's sequence through a second handle, the way `node.Setattr` does. Against the unchanged code the test fails with `corrupt block #0` and EIO; with the fix the first block reads back as the expected 8 bytes plus zero padding, the payload at 4096 is intact, and shrinking again succeeds. `go test -tags without_openssl ./internal/...` passes for 13 packages with and without the change; the one failure in both is `TestGetdents`, which is unrelated (it inspects `/dev` inside the container).
